### PR TITLE
Updated htcondor execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,20 @@ This example will run over two files from two different datasets, produce MET an
 Have a look at the code to see how this works under the hood. Also check out the [examples in the Coffea repository](https://github.com/CoffeaTeam/coffea/tree/master/binder), which are much more detailed than this one.
 
 
-### Running over larger data sets
+### Running the analysis
+
+#### Just over a few files
+
+Check out the `./scripts/run_quick_monojet.py` script to see how to quickly run over a few handpicked files, which may be useful for testing. The output will be saved in a file named `monojet_${dataset}.coffea` depending on the name of the dataset you ran over. If you want to look at a few simple histogram plots, you can run a simple plotter with your output:
+
+```
+./scripts/print_plots.py monojet_${dataset}.coffea
+```
+
+You can check out the code in the script to see how it's done.
+
+
+#### Using large data sets
 
 Currently, HTCondor submission is used to run over large numbers of input files. The submission is implemented in the `execute.py` script.
 To get the idea, you run a test job to process some of the SingleMuon data:

--- a/README.md
+++ b/README.md
@@ -47,16 +47,15 @@ Currently, HTCondor submission is used to run over large numbers of input files.
 To get the idea, you run a test job to process some of the SingleMuon data:
 
 ```bash
-./execute//execute.py -j4 monojet --datasrc 'eos' submit --dataset 'SingleMuon_2017B' --filesperjob 30 --name "test_submission" --no-prefetch --async
+buexec -j4  --datasrc 'eos' monojet submit --dataset 'SingleMuon_2017B'--async --filesperjob 30 --name "test_submission"
 ```
 
 This will submit an HTCondor job running on 4 CPUs per node (`-j4`), to run over pre-processed data from my EOS area (`--datasrc eos`). Files related to job submission, as well as the job output can be found in the `submission/test_submission/` directory. Check it out!
+The submission script will automatically detect whether you are running on lxplus or at FNAL and will adapt accordingly.
 
-Note that the worker jobs rely on accessing all the executable code from the virtual environment you are using to submit the jobs. Therefore, make sure to have your virtual environment accessible on a shared file system like AFS.
+If you are running a larger number of jobs, it's easy to loose track of them. The `bumon` tool will allow you to track all jobs belonging to a given submission. Usage is easy:
 
-If you are running a larger number of jobs, it's easy to loose track of them. The `monitor.py` script will allow you to track all jobs belonging to a given submission. Usage is easy:
-
-`./execute/monitor.py submission/*test_submission/files`
+`bumon submission/test_submission/`
 
 ### XROOTD
 Ignore for now.

--- a/bucoffea/execute/buexec
+++ b/bucoffea/execute/buexec
@@ -156,7 +156,7 @@ def do_submit(args):
         input_files.append(gridpack_path)
 
     for dataset, files in dataset_files.items():
-        print(f"Submitting dataset: {dataset}.")
+        print(f"Writing submission files for dataset: {dataset}.")
 
         chunks = chunkify(files,int(len(files) / args.filesperjob + 1) )
         for ichunk, chunk in enumerate(chunks):
@@ -224,6 +224,7 @@ def do_submit(args):
                     jobid = condor_submit(jdl)
                     print(f"Submitted job {jobid}")
     if args.async:
+        print('Starting asynchronous submission.')
         p = Pool(processes=8)
         res = p.map_async(condor_submit, jdl_to_submit)
         res.wait()

--- a/bucoffea/execute/buexec
+++ b/bucoffea/execute/buexec
@@ -19,6 +19,9 @@ from bucoffea.helpers.condor import condor_submit
 from bucoffea.helpers.git import git_rev_parse, git_diff
 from bucoffea.processor.executor import run_uproot_job_nanoaod
 
+
+import socket
+
 pjoin = os.path.join
 
 def choose_processor(args):
@@ -93,6 +96,17 @@ def chunkify(items, nchunk):
         chunks[i % nchunk].append(items[i])
     return chunks
 
+import tarfile
+def pack_and_copy_repo():
+    tar = tarfile.open('gp.tgz','w')
+    tar.add(
+        name=os.path.dirname(bucoffea_path('')),
+        arcname='bucoffea',
+        exclude=lambda x: ('tgz' in x or 'sf' in x)
+        )
+    tar.close()
+    return
+
 def do_submit(args):
     """Submit the analysis to HTCondor."""
     import htcondor
@@ -144,6 +158,9 @@ def do_submit(args):
     if args.async:
         jdl_to_submit = []
 
+    if args.send_pack:
+        gridpack_path = pack_and_copy_repo()
+    
     for dataset, files in dataset_files.items():
         print(f"Submitting dataset: {dataset}.")
 
@@ -157,7 +174,6 @@ def do_submit(args):
 
             # Job file creation
             arguments = [
-                str(Path(__file__).absolute()),
                 args.processor,
                 f'--outpath {pjoin(subdir, "output")}',
                 f'--jobs {args.jobs}',
@@ -170,9 +186,15 @@ def do_submit(args):
                 os.path.abspath(tmpfile),
             ]
             environment = {
-                "X509_USER_PROXY" : "$(Proxy_path)",
                 "NOPREFETCH" : str(args.no_prefetch).lower()
             }
+            if args.send_proxy:
+                environment["X509_USER_PROXY"] = "$(Proxy_path)"
+            if args.send_pack:
+                environment["BUCOFFEAGRIDPACK"] = gridpack_path
+            else:
+                environment["VIRTUAL_ENV"] = os.environ["VIRTUAL_ENV"]
+                environment["BUCOFFEAEXECUTABLE"] = str(Path(__file__).absolute())
             sub = htcondor.Submit({
                 "Proxy_path" : pjoin(proxydir,os.path.basename(proxy)),
                 "Initialdir" : subdir,
@@ -180,7 +202,6 @@ def do_submit(args):
                 "should_transfer_files" : "YES",
                 "when_to_transfer_output" : "ON_EXIT",
                 "transfer_input_files" : ", ".join(input_files),
-                "getenv" : "true",
                 "environment" : '"' + ' '.join([f"{k}={v}" for k, v in environment.items()]) + '"',
                 "arguments": " ".join(arguments),
                 "Output" : f"{filedir}/out_{dataset}_{ichunk:03d}of{len(chunks):03d}.txt",
@@ -252,6 +273,13 @@ def main():
 
     args = parser.parse_args()
 
+    host = socket.gethostname()
+    if 'lpc' in host:
+        args.send_pack = True
+        args.send_proxy = False
+    elif 'lxplus' in host:
+        args.send_pack = False
+        args.send_proxy = True
     args.func(args)
 
 

--- a/bucoffea/execute/buexec
+++ b/bucoffea/execute/buexec
@@ -18,7 +18,7 @@ from bucoffea.helpers import bucoffea_path, vo_proxy_path, xrootd_format
 from bucoffea.helpers.condor import condor_submit
 from bucoffea.helpers.git import git_rev_parse, git_diff
 from bucoffea.processor.executor import run_uproot_job_nanoaod
-
+from bucoffea.helpers.deployment import pack_repo
 
 import socket
 
@@ -43,6 +43,7 @@ def do_run(args):
     else:
         fileset = files_from_eos(regex=args.dataset)
 
+    print(fileset)
     for dataset, files in fileset.items():
         output = run_uproot_job_nanoaod({dataset:files},
                                     treename='Events',
@@ -96,16 +97,6 @@ def chunkify(items, nchunk):
         chunks[i % nchunk].append(items[i])
     return chunks
 
-import tarfile
-def pack_and_copy_repo():
-    tar = tarfile.open('gp.tgz','w')
-    tar.add(
-        name=os.path.dirname(bucoffea_path('')),
-        arcname='bucoffea',
-        exclude=lambda x: ('tgz' in x or 'sf' in x)
-        )
-    tar.close()
-    return
 
 def do_submit(args):
     """Submit the analysis to HTCondor."""
@@ -158,9 +149,12 @@ def do_submit(args):
     if args.async:
         jdl_to_submit = []
 
+    input_files = []
     if args.send_pack:
-        gridpack_path = pack_and_copy_repo()
-    
+        gridpack_path = pjoin(subdir, 'gridpack.tgz')
+        pack_repo(gridpack_path)
+        input_files.append(gridpack_path)
+
     for dataset, files in dataset_files.items():
         print(f"Submitting dataset: {dataset}.")
 
@@ -175,33 +169,35 @@ def do_submit(args):
             # Job file creation
             arguments = [
                 args.processor,
-                f'--outpath {pjoin(subdir, "output")}',
+                f'--outpath .',
                 f'--jobs {args.jobs}',
                 'worker',
                 f'--dataset {dataset}',
                 f'--filelist {os.path.basename(tmpfile)}',
                 f'--chunk {ichunk}'
             ]
-            input_files = [
+
+            job_input_files = input_files + [
                 os.path.abspath(tmpfile),
             ]
+
+
             environment = {
                 "NOPREFETCH" : str(args.no_prefetch).lower()
             }
             if args.send_proxy:
                 environment["X509_USER_PROXY"] = "$(Proxy_path)"
-            if args.send_pack:
-                environment["BUCOFFEAGRIDPACK"] = gridpack_path
-            else:
+            if not args.send_pack:
                 environment["VIRTUAL_ENV"] = os.environ["VIRTUAL_ENV"]
-                environment["BUCOFFEAEXECUTABLE"] = str(Path(__file__).absolute())
+            if args.debug:
+                environment['BUCOFFEADEBUG'] = 'true'
             sub = htcondor.Submit({
                 "Proxy_path" : pjoin(proxydir,os.path.basename(proxy)),
                 "Initialdir" : subdir,
                 "executable": bucoffea_path("execute/htcondor_wrap.sh"),
                 "should_transfer_files" : "YES",
                 "when_to_transfer_output" : "ON_EXIT",
-                "transfer_input_files" : ", ".join(input_files),
+                "transfer_input_files" : ", ".join(job_input_files),
                 "environment" : '"' + ' '.join([f"{k}={v}" for k, v in environment.items()]) + '"',
                 "arguments": " ".join(arguments),
                 "Output" : f"{filedir}/out_{dataset}_{ichunk:03d}of{len(chunks):03d}.txt",
@@ -212,7 +208,7 @@ def do_submit(args):
                 "+MaxRuntime" : f"{60*60*8}"
                 })
 
-            jdl = pjoin(subdir,filedir,f'job_{dataset}_{ichunk:03d}of{len(chunks):03d}.jdl')
+            jdl = pjoin(subdir,filedir,f'job_{dataset}_{ichunk}.jdl')
             with open(jdl,"w") as f:
                 f.write(str(sub))
                 f.write("\nqueue 1\n")
@@ -268,6 +264,7 @@ def main():
     parser_submit.add_argument('--test', action="store_true", default=False, help='Only run over one file per dataset for testing.')
     parser_submit.add_argument('--force', action="store_true", default=False, help='Overwrite existing submission folder with same tag.')
     parser_submit.add_argument('--async', action="store_true", default=False, help='Submit asynchronously.')
+    parser_submit.add_argument('--debug', action="store_true", default=False, help='Print debugging info.')
     parser_submit.set_defaults(func=do_submit)
 
 

--- a/bucoffea/execute/buexec
+++ b/bucoffea/execute/buexec
@@ -183,7 +183,7 @@ def do_submit(args):
 
 
             environment = {
-                "NOPREFETCH" : str(args.no_prefetch).lower()
+                "BUCOFFEAPREFETCH" : str(args.prefetch).lower()
             }
             if args.send_proxy:
                 environment["X509_USER_PROXY"] = "$(Proxy_path)"
@@ -259,7 +259,8 @@ def main():
     parser_submit.add_argument('--dataset', type=str, help='Dataset regex to use.')
     parser_submit.add_argument('--filesperjob', type=int, default=10, help='Number of files to process per job')
     parser_submit.add_argument('--name', type=str, default=None, help='Name to identify this submission')
-    parser_submit.add_argument('--no-prefetch', action="store_true", default=False, help='Do not prefetch input files on worker but run over xrootd.')
+    parser_submit.add_argument('--prefetch', action="store_true", default=False, help='Prefetch input files on worker but run over xrootd.')
+    parser_submit.add_argument('--no-prefetch', action="store_true", default=False, help='DEPRECATED. Prefetching is now disabled by default. Use --prefetch to activate prefetching.')
     parser_submit.add_argument('--dry', action="store_true", default=False, help='Do not trigger submission, just dry run.')
     parser_submit.add_argument('--test', action="store_true", default=False, help='Only run over one file per dataset for testing.')
     parser_submit.add_argument('--force', action="store_true", default=False, help='Overwrite existing submission folder with same tag.')
@@ -267,6 +268,8 @@ def main():
     parser_submit.add_argument('--debug', action="store_true", default=False, help='Print debugging info.')
     parser_submit.set_defaults(func=do_submit)
 
+    if args.no_prefetch:
+        print("WARNING: --no-prefetch is deprecated. Prefetching is disabled by default. Use --prefetch  if you want to turn it back on")
 
     args = parser.parse_args()
 
@@ -275,7 +278,7 @@ def main():
         args.send_pack = True
         args.send_proxy = False
     elif 'lxplus' in host:
-        args.send_pack = False
+        args.send_pack = True
         args.send_proxy = True
     args.func(args)
 

--- a/bucoffea/execute/bumon
+++ b/bucoffea/execute/bumon
@@ -27,6 +27,9 @@ def main(stdscr):
     curses.init_pair(3, curses.COLOR_WHITE, -1)
 
     directories = sys.argv[1:]
+    for directory in directories:
+        if not os.path.exists(directory):
+            raise RuntimeError(f"Directory does not exist: {directory}. Please check your arguments.")
 
     def read_logs():
         log_list = []

--- a/bucoffea/execute/execute.py
+++ b/bucoffea/execute/execute.py
@@ -157,8 +157,6 @@ def do_submit(args):
 
             # Job file creation
             arguments = [
-                # pjoin(proxydir, os.path.basename(proxy)),
-                "$(Proxy_path)",
                 str(Path(__file__).absolute()),
                 args.processor,
                 f'--outpath {pjoin(subdir, "output")}',
@@ -172,6 +170,7 @@ def do_submit(args):
                 os.path.abspath(tmpfile),
             ]
             environment = {
+                "X509_USER_PROXY" : "$(Proxy_path)",
                 "NOPREFETCH" : str(args.no_prefetch).lower()
             }
             sub = htcondor.Submit({

--- a/bucoffea/execute/htcondor_wrap.sh
+++ b/bucoffea/execute/htcondor_wrap.sh
@@ -7,10 +7,11 @@ echo "Starting: $(date)"
 source /cvmfs/sft.cern.ch/lcg/views/LCG_95apython3/x86_64-centos7-gcc8-opt/setup.sh
 
 ARGS=("$@")
-echo "Arguments: " ${ARGS[@]}
-echo "Initiating VOMS proxy."
-export X509_USER_PROXY=${1}
-voms-proxy-info -all -file ${1}
+
+if [ ! -z "${X509_USER_PROXY}" ]; then
+    echo "Initiating VOMS proxy."
+    voms-proxy-info -all -file ${X509_USER_PROXY}
+fi
 
 if [ ! -z "${VIRTUAL_ENV}" ]; then
     echo "Found VIRTUAL_ENV variable."
@@ -31,7 +32,7 @@ if [ ! "$NOPREFETCH" = true ]; then
     mv tmp.txt $FLIST
 fi
 
-executable=${2}
+executable=${1}
 cp -v ${executable} .
 
 echo "Directory content---"
@@ -40,7 +41,7 @@ echo "===================="
 
 
 echo "Setup done: $(date)"
-time python $(basename ${executable}) ${ARGS[@]:2}
+time python $(basename ${executable}) ${ARGS[@]:1}
 echo "Run done: $(date)"
 
 echo "Cleaning up."

--- a/bucoffea/execute/htcondor_wrap.sh
+++ b/bucoffea/execute/htcondor_wrap.sh
@@ -28,7 +28,7 @@ else
 fi
 
 # Copy files to local disk before running
-if [ ! "$NOPREFETCH" = true ]; then
+if [ "$BUCOFFEAPREFETCH" = true ]; then
     echo "Prefetching."
     FLIST=$(readlink -e input*.txt)
     touch tmp.txt

--- a/bucoffea/execute/htcondor_wrap.sh
+++ b/bucoffea/execute/htcondor_wrap.sh
@@ -5,6 +5,8 @@ if [ "$BUCOFFEADEBUG" = true ]; then
 fi
 echo "Starting: $(date)"
 source /cvmfs/sft.cern.ch/lcg/views/LCG_95apython3/x86_64-centos7-gcc8-opt/setup.sh
+echo "Using python at: $(which python)"
+python --version
 
 ARGS=("$@")
 
@@ -16,8 +18,16 @@ fi
 if [ ! -z "${VIRTUAL_ENV}" ]; then
     echo "Found VIRTUAL_ENV variable."
     source ${VIRTUAL_ENV}/bin/activate
+    cp "${BUCOFFEAEXECUTABLE}" .
+    executable=$(basename "${BUCOFFEAEXECUTABLE}")
+else
+    tar xf *tgz
+    rm -rvf *tgz
+    ENVNAME="bucoffeaenv"
+    python -m venv ${ENVNAME}
+    source ${ENVNAME}/bin/activate
+    python -m pip install -e bucoffea --no-cache-dir
 fi
-echo "Using python at: $(which python)"
 
 # Copy files to local disk before running
 if [ ! "$NOPREFETCH" = true ]; then
@@ -32,21 +42,17 @@ if [ ! "$NOPREFETCH" = true ]; then
     mv tmp.txt $FLIST
 fi
 
-executable=${1}
-cp -v ${executable} .
-
 echo "Directory content---"
 ls -lah .
 echo "===================="
 
 
 echo "Setup done: $(date)"
-time python $(basename ${executable}) ${ARGS[@]:1}
+time buexec ${ARGS[@]}
 echo "Run done: $(date)"
 
 echo "Cleaning up."
 rm -vf *.root
 rm -vf ${FLIST}
-rm -vf $(basename $executable)
 echo "End: $(date)"
 

--- a/bucoffea/execute/htcondor_wrap.sh
+++ b/bucoffea/execute/htcondor_wrap.sh
@@ -18,8 +18,6 @@ fi
 if [ ! -z "${VIRTUAL_ENV}" ]; then
     echo "Found VIRTUAL_ENV variable."
     source ${VIRTUAL_ENV}/bin/activate
-    cp "${BUCOFFEAEXECUTABLE}" .
-    executable=$(basename "${BUCOFFEAEXECUTABLE}")
 else
     tar xf *tgz
     rm -rvf *tgz

--- a/bucoffea/helpers/condor.py
+++ b/bucoffea/helpers/condor.py
@@ -1,15 +1,25 @@
 #!/usr/bin/env python
 
 import subprocess
-
+import socket
 def condor_submit(jobfile):
-    cmd = ["condor_submit", jobfile]
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    host = socket.gethostname()
+    if 'lxplus' in host:
+        cmd = ["condor_submit", jobfile]
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
 
-    stdout, stderr = proc.communicate()
-    if proc.returncode != 0:
-        raise RuntimeError(f"Condor submission failed. Stderr:\n {stderr}.")
-    jobid = stdout.split()[-1].decode('utf-8').replace('.','')
+        stdout, stderr = proc.communicate()
+        if proc.returncode != 0:
+            raise RuntimeError(f"Condor submission failed. Stderr:\n {stderr}.")
+        jobid = stdout.split()[-1].decode('utf-8').replace('.','')
+    elif 'fnal' in host:
+        cmd = ["bash","/usr/local/bin/condor_submit", jobfile]
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+
+        stdout, stderr = proc.communicate()
+        if proc.returncode != 0:
+            raise RuntimeError(f"Condor submission failed. Stderr:\n {stderr}.")
+        jobid = stdout.split()[-1].decode('utf-8').replace('.','')
     return jobid
 
 

--- a/bucoffea/helpers/deployment.py
+++ b/bucoffea/helpers/deployment.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+import tarfile
+import os
+
+from bucoffea.helpers.paths import bucoffea_path
+
+
+def get_repo_files():
+    '''Returns a list of tracked files in the bucoffea repo'''
+    import git
+
+    repo = git.Repo(bucoffea_path('..'))
+
+    to_iterate = [repo.tree()]
+    to_add = []
+
+    while len(to_iterate):
+        for item in to_iterate.pop():
+            if item.type == 'tree':
+                to_iterate.append(item)
+            elif item.type == 'blob':
+                to_add.append(item.abspath)
+    return to_add
+
+
+
+def pack_repo(path_to_gridpack):
+    '''Creates a gridpack containing the bucoffea repo'''
+    if os.path.exists(path_to_gridpack):
+        raise RuntimeError(f"Gridpack file already exists. Will not overwrite {path_to_gridpack}.")
+    tar = tarfile.open(path_to_gridpack,'w')
+    files = get_repo_files()
+    for f in files:
+        tar.add(
+            name=f,
+            arcname=f.replace(os.path.abspath(bucoffea_path('../..')),''),
+            exclude=lambda x: ('tgz' in x or 'submission' in x)
+            )
+    tar.close()
+    return

--- a/bucoffea/scripts/print_plots.py
+++ b/bucoffea/scripts/print_plots.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import sys
+from bucoffea.plot.debug import debug_plot_output
+from coffea.util import load, save
+import argparse
+def commandline():
+    parser = argparse.ArgumentParser(prog='Quick and dirty plot dumper from coffea output.')
+    parser.add_argument('file', type=str, help='Input file to use.')
+    parser.add_argument('--outpath', type=str, help='Path to save output under.', default='./out')
+    parser.add_argument('--region', type=str, default='inclusive', help='Region to plot.')
+    args = parser.parse_args()
+    return args
+
+def main():
+    args = commandline()
+    acc = load(args.file)
+    debug_plot_output(acc, args.region)
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ coffea==0.6.8
 htcondor
 dynaconf
 pyyaml
+gitpython
+tabulate

--- a/setup.py
+++ b/setup.py
@@ -12,4 +12,5 @@ setup(
     description = 'Analysis using Coffea on NanoAOD',
     packages = find_packages(),    
     install_requires = requirements,
+    scripts=['bucoffea/execute/buexec'],
 )

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,8 @@ setup(
     description = 'Analysis using Coffea on NanoAOD',
     packages = find_packages(),    
     install_requires = requirements,
-    scripts=['bucoffea/execute/buexec'],
+    scripts=[
+        'bucoffea/execute/buexec',
+        'bucoffea/execute/bumon'
+        ],
 )


### PR DESCRIPTION
This PR has the following changes:
* htcondor now works at both fnal and lxplus
* instead of using the software environment from a shared file system, a gridpack with the code is created and sent with each job.
* The README has been udpated to reflect these changes.
* `execute.py` has been renamed to `buexec` and is now registered as an executable upon installation of the package.
* Same for `monitor.py` -> `bumon`
* The default submission options have been updated, so that prefetching is disabled by default.