### PR TITLE
fix potential full pipe when merging big files with bumerge

### DIFF
--- a/bucoffea/helpers/merging.py
+++ b/bucoffea/helpers/merging.py
@@ -60,7 +60,7 @@ def _load_and_sum(args):
                     memsize=1e3,
                     )
     arc[key] = items[0]
-    arc.dump()
+    arc.dump(key)
     arc.clear()
     return 0
 
@@ -96,14 +96,6 @@ class CoffeaMerger(object):
         '''
         Run the merging and save to a klepto dir.
         '''
-
-        # Open the archive
-        arc = dir_archive(
-                        outname,
-                        serialized=True,
-                        compression=0,
-                        memsize=1e3,
-                        )
 
         # Queue asynchronous jobs for each key
         results = []

--- a/bucoffea/monojet/definitions.py
+++ b/bucoffea/monojet/definitions.py
@@ -54,8 +54,8 @@ def monojet_accumulator(cfg):
 
     ratio_ax = Bin("ratio", "ratio", 50,0,2)
 
-    tau21_ax = Bin("tau21", r"Tagger", 200,-5,5)
-    tagger_ax = Bin("tagger", r"Tagger", 50,-5,5)
+    tau21_ax = Bin("tau21", r"Tagger", 50,0,1)
+    tagger_ax = Bin("tagger", r"Tagger", 50,0,1)
 
     dilepton_mass_ax = Bin("dilepton_mass", r"$M(\ell\ell)$ (GeV)", 50,50,150)
 
@@ -438,7 +438,7 @@ def monojet_regions(cfg):
     regions['cr_nobveto_v'].remove('veto_b')
 
     # additional regions to test out deep ak8 WvsQCD tagger
-    for region in ['sr_v','cr_2m_v','cr_1m_v','cr_2e_v','cr_1e_v','cr_g_v']:
+    for region in ['sr_v','cr_2m_v','cr_1m_v','cr_2e_v','cr_1e_v','cr_g_v','cr_nobveto_v']:
         for wp in ['inclusive', 'loose', 'tight','loosemd','tightmd']:
             # the new region name will be, for example, cr_2m_loose_v
             newRegionName=region.replace('_v','_'+wp+'_v')

--- a/bucoffea/monojet/definitions.py
+++ b/bucoffea/monojet/definitions.py
@@ -450,11 +450,11 @@ def monojet_regions(cfg):
                 regions[newRegionName].append('leadak8_wvsqcd_'+wp)
 
     if not cfg.RUN.MONOV:
-        keys_to_remove = [ x for x in regions.keys() if x.endswith('_v')]
+        keys_to_remove = [ x for x in regions.keys() if x.endswith('_v') or '_v_' in x]
         for key in keys_to_remove:
             regions.pop(key)
     if not cfg.RUN.MONOJ:
-        keys_to_remove = [ x for x in regions.keys() if x.endswith('_j')]
+        keys_to_remove = [ x for x in regions.keys() if x.endswith('_j') or '_j_' in x]
         for key in keys_to_remove:
             regions.pop(key)
 

--- a/bucoffea/plot/style.py
+++ b/bucoffea/plot/style.py
@@ -1144,11 +1144,79 @@ def plot_settings():
                 'xlim' : (-3,3),
                 'ylim' : (1e-1,1e5)
             }
+        },
+        'cr_nobveto_v' : {
+            'ak8_mass0' : {
+                'xlim' : (60,110),
+                'ylim' : (1e-1,1e5)
+            },
+            'ak8_tau210' : {
+                'xlim' : (0,1),
+                'ylim' : (1e-1,1e6)
+            },
+            'recoil' : {
+                'ylim' : (1e-4,1e3)
+            },
+            'ak8_pt0' : {
+                'xlim' : (200,1000),
+                'ylim' : (1e-2,1e4)
+            },
+            'met' : {
+                'xlim' : (200,2000),
+                'ylim' : (1e-4,1e3)
+            },
+            'ak8_phi0' : {
+                'ylim' : (1e1,1e5)
+            },
+            'ak8_eta0' : {
+                'xlim' : (-3,3),
+                'ylim' : (1e-1,1e5)
+            },
+            'ak8_wvsqcd0' : {
+                'xlim' : (0,1)
+            },
+            'ak8_wvsqcdmd0' : {
+                'xlim' : (0,1)
+            }
+        },
+        'cr_sr_v' : {
+            'ak8_mass0' : {
+                'xlim' : (60,110),
+                'ylim' : (1e-1,1e5)
+            },
+            'ak8_tau210' : {
+                'xlim' : (0,1),
+                'ylim' : (1e-1,1e6)
+            },
+            'recoil' : {
+                'ylim' : (1e-4,1e4)
+            },
+            'ak8_pt0' : {
+                'xlim' : (200,1000),
+                'ylim' : (1e-2,1e4)
+            },
+            'met' : {
+                'xlim' : (200,2000),
+                'ylim' : (1e-4,1e4)
+            },
+            'ak8_phi0' : {
+                'ylim' : (1e1,1e5)
+            },
+            'ak8_eta0' : {
+                'xlim' : (-3,3),
+                'ylim' : (1e-1,1e5)
+            },
+            'ak8_wvsqcd0' : {
+                'xlim' : (0,1)
+            },
+            'ak8_wvsqcdmd0' : {
+                'xlim' : (0,1)
+            }
         }
         }
     )
     # add axes limit for control regions with different working points
-    for raw_region in ['sr_v','cr_2m_v','cr_1m_v','cr_2e_v','cr_2e_v','cr_g_v','cr_nobveto_v']:
+    for raw_region in ['sr_v','cr_2m_v','cr_1m_v','cr_1e_v','cr_2e_v','cr_g_v','cr_nobveto_v']:
         # add default axes limits for these regions:
         plot_settings[raw_region]['ak8_wvsqcd0']={
             'xlim' : (0,1)
@@ -1156,7 +1224,7 @@ def plot_settings():
         plot_settings[raw_region]['ak8_wvsqcdmd0']={
             'xlim' : (0,1)
         }
-        for wp in ['inclusive','loose','tight','loosemd','tightmd']:
+        for wp in ['inclusive','loose','loosemd']:
             region = raw_region.replace('_v','_'+wp+'_v')
             plot_settings[region] = {
                 'ak8_mass0' : {
@@ -1168,6 +1236,7 @@ def plot_settings():
                     'ylim' : (1e-1,1e6)
                 },
                 'recoil' : {
+                    'xlim' : (200,2000),
                     'ylim' : (1e-4,1e4)
                 },
                 'ak8_pt0' : {
@@ -1175,7 +1244,7 @@ def plot_settings():
                     'ylim' : (1e-2,1e4)
                 },
                 'met' : {
-                    'xlim' : (0,1100),
+                    'xlim' : (200,2000),
                     'ylim' : (1e-4,1e4)
                 },
                 'ak8_phi0' : {
@@ -1188,7 +1257,7 @@ def plot_settings():
                 'ak8_wvsqcd0' : {
                     'xlim' : (0,1)
                 },
-                'ak8_wvsqcd0md' : {
+                'ak8_wvsqcdmd0' : {
                     'xlim' : (0,1)
                 }
             }
@@ -1196,6 +1265,43 @@ def plot_settings():
                 plot_settings[region]['ak8_mass0']={
                     'ylim' : (1e-1,1e5)
                 }
+        for wp in ['tight','tightmd']:
+            region = raw_region.replace('_v','_'+wp+'_v')
+            plot_settings[region] = {
+                'ak8_mass0' : {
+                    'xlim' : (60,110),
+                    'ylim' : (1e-3,1e3)
+                },
+                'ak8_tau210' : {
+                    'xlim' : (0,1),
+                    'ylim' : (1e-3,1e4)
+                },
+                'recoil' : {
+                    'xlim' : (200,2000),
+                    'ylim' : (1e-6,1e2)
+                },
+                'ak8_pt0' : {
+                    'xlim' : (200,1000),
+                    'ylim' : (1e-4,1e2)
+                },
+                'met' : {
+                    'xlim' : (200,2000),
+                    'ylim' : (1e-6,1e2)
+                },
+                'ak8_phi0' : {
+                    'ylim' : (1e-1,1e3)
+                },
+                'ak8_eta0' : {
+                    'xlim' : (-3,3),
+                    'ylim' : (1e-3,1e3)
+                },
+                'ak8_wvsqcd0' : {
+                    'xlim' : (0,1)
+                },
+                'ak8_wvsqcdmd0' : {
+                    'xlim' : (0,1)
+                }
+            }
     return plot_settings
 
 def tangocolor( palettenumber, colornumber):


### PR DESCRIPTION
Transferring the merged item between the child process and the parent process could potentially block the pipeline. To avoid that, we should instead let the child processes read, merge, and write on its own without transferring any data between processes.
