### PR TITLE
Remove setup commands for bucoffeaenv

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,0 @@
-source /cvmfs/sft.cern.ch/lcg/views/LCG_95apython3/x86_64-centos7-gcc8-opt/setup.sh
-source ../bucoffeaenv/bin/activate
-export PYTHONPATH=$(readlink -e ../bucoffeaenv/lib/python3.6/site-packages/):${PYTHONPATH}
-

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
 source /cvmfs/sft.cern.ch/lcg/views/LCG_95apython3/x86_64-centos7-gcc8-opt/setup.sh
 source ../bucoffeaenv/bin/activate
-export PYTHONPATH=$(readlink -e ~/bucoffeaenv/lib/python3.6/site-packages/):${PYTHONPATH}
+export PYTHONPATH=$(readlink -e ../bucoffeaenv/lib/python3.6/site-packages/):${PYTHONPATH}
 


### PR DESCRIPTION
Update setup commands to be compatible with both LXPlus and LPC