### PR TITLE
19Feb20 skim

### DIFF
--- a/bucoffea/execute/dataset_definitions.py
+++ b/bucoffea/execute/dataset_definitions.py
@@ -199,7 +199,7 @@ def files_from_eos(regex):
                 fileset[key] = fileset_16jul[key]
     elif 'lpc' in host:
         topdir = '/eos/uscms/store/user/aandreas/nanopost/'
-        tag = '06Jan20'
+        tag = '19Feb20'
         fileset = find_files_eos(pjoin(topdir, tag), regex)
 
     return fileset


### PR DESCRIPTION
@siqiyuan With this update, we have the top tagging score available:

```
root [4] Events->Print("FatJet*deepTag*T*")
******************************************************************************
*Tree    :Events    : Events                                                 *
*Entries :   571987 : Total =      2371948805 bytes  File  Size =  822514304 *
*        :          : Tree compression factor =   2.88                       *
******************************************************************************
*Br    0 :FatJet_deepTagMD_TvsQCD :                                          *
*         | Float_t Mass-decorrelated DeepBoostedJet tagger top vs QCD discriminator*
*Entries :   571987 : Total  Size=    5681006 bytes  File Size  =    2064824 *
*Baskets :      128 : Basket Size=      62464 bytes  Compression=   2.75     *
*............................................................................*
*Br    1 :FatJet_deepTag_TvsQCD :                                            *
*         | Float_t DeepBoostedJet tagger top vs QCD discriminator           *
*Entries :   571987 : Total  Size=    5680726 bytes  File Size  =    2185624 *
*Baskets :      128 : Basket Size=      62464 bytes  Compression=   2.60     *
*............................................................................*
```