### PR TITLE
Single + double top merging

### DIFF
--- a/bucoffea/limit/legacy_monojet.py
+++ b/bucoffea/limit/legacy_monojet.py
@@ -33,12 +33,12 @@ def datasets(year):
 
  
     mc = {
-                'cr_1m_j' : re.compile(f'(TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|.*WJetsToLNu.*HT.*).*{year}'),
-                'cr_1e_j' : re.compile(f'(TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|.*WJetsToLNu.*HT.*).*{year}'),
-                'cr_2m_j' : re.compile(f'(TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*).*{year}'),
-                'cr_2e_j' : re.compile(f'(TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*).*{year}'),
+                'cr_1m_j' : re.compile(f'(Top_FXFX|Diboson.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|.*WJetsToLNu.*HT.*).*{year}'),
+                'cr_1e_j' : re.compile(f'(Top_FXFX|Diboson.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|.*WJetsToLNu.*HT.*).*{year}'),
+                'cr_2m_j' : re.compile(f'(Top_FXFX|Diboson.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*).*{year}'),
+                'cr_2e_j' : re.compile(f'(Top_FXFX|Diboson.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*).*{year}'),
                 'cr_g_j' : re.compile(f'(GJets_DR-0p4.*|QCD_data.*|WJetsToLNu.*HT.*).*{year}'),
-                'sr_j' : re.compile(f'(.*WJetsToLNu.*HT.*|.*ZJetsToNuNu.*HT.*|W.*HT.*|TTJets.*FXFX.*|Diboson.*|QCD_HT.*|.*Hinv.*|.*HToInv.*).*{year}'),
+                'sr_j' : re.compile(f'(.*WJetsToLNu.*HT.*|.*ZJetsToNuNu.*HT.*|W.*HT.*|Top_FXFX.*|Diboson.*|QCD_HT.*|.*Hinv.*|.*HToInv.*).*{year}'),
             }
     for key in list(mc.keys()):
         new_key = key.replace('_j','_v')
@@ -50,7 +50,7 @@ def legacy_dataset_name(dataset):
     patterns = {
         '.*DY.*' : 'zll',
         'QCD.*' : 'qcd',
-        'TTJets.*' : 'top',
+        '(Top).*' : 'top',
         'Diboson.*' : 'diboson',
         '(MET|EGamma).*' : 'data',
         'WJetsToLNu.*' : 'wjets',

--- a/bucoffea/limit/legacy_vbf.py
+++ b/bucoffea/limit/legacy_vbf.py
@@ -25,11 +25,11 @@ def datasets(year):
                     'sr_vbf' : f'nomatch',
                 }
     mc = {
-            'sr_vbf' : re.compile(f'W(minus|plus)H_.*|((VBF|GluGlu)_HToInvisible.*|ggZH.*|ZJetsToNuNu.*|EW.*|TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|DYJetsToLL.*|.*W.*HT.*).*{year}'),
-            'cr_1m_vbf' : re.compile(f'(EW.*|TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|.*W.*HT.*).*{year}'),
-            'cr_1e_vbf' : re.compile(f'(EW.*|TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|.*W.*HT.*).*{year}'),
-            'cr_2m_vbf' : re.compile(f'(EW.*|TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*).*{year}'),
-            'cr_2e_vbf' : re.compile(f'(EW.*|TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*).*{year}'),
+            'sr_vbf' : re.compile(f'W(minus|plus)H_.*|((VBF|GluGlu)_HToInvisible.*|ggZH.*|ZJetsToNuNu.*|EW.*|Top_FXFX.*|Diboson.*|QCD_HT.*|DYJetsToLL.*|WJetsToLNu.*HT.*).*{year}'),
+            'cr_1m_vbf' : re.compile(f'(EW.*|Top_FXFX.*|Diboson.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|WJetsToLNu.*HT.*).*{year}'),
+            'cr_1e_vbf' : re.compile(f'(EW.*|Top_FXFX.*|Diboson.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|WJetsToLNu.*HT.*).*{year}'),
+            'cr_2m_vbf' : re.compile(f'(EW.*|Top_FXFX.*|Diboson.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*).*{year}'),
+            'cr_2e_vbf' : re.compile(f'(EW.*|Top_FXFX.*|Diboson.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*).*{year}'),
             'cr_g_vbf' : re.compile(f'(GJets_(DR-0p4|SM).*|QCD_data.*|WJetsToLNu.*HT.*).*{year}'),
           }
         
@@ -47,7 +47,7 @@ def legacy_dataset_name_vbf(dataset):
         'EWKZ\d?Jets.*ZToNuNu.*' : 'ewkzjets',
         'EWKW.*' : 'ewkwjets',
         'QCD.*' : 'qcd',
-        'TTJets.*' : 'top',
+        'Top.*' : 'top',
         'Diboson.*' : 'diboson',
         '(MET|EGamma).*' : 'data',
         'WJetsToLNu.*' : 'qcdwjets',

--- a/bucoffea/plot/studies/lo_vs_nlo/lo_vs_nlo.py
+++ b/bucoffea/plot/studies/lo_vs_nlo/lo_vs_nlo.py
@@ -62,10 +62,10 @@ def plot(inpath):
             # Match datasets by regular expressions
             # Here for LO V samples (HT binned)
             mc_lo = {
-                'cr_1m_j' : re.compile(f'(TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|.*WJetsToLNu.*HT.*).*{year}'),
-                'cr_1e_j' : re.compile(f'(TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|.*WJetsToLNu.*HT.*|GJets_DR.*HT.*).*{year}'),
-                'cr_2m_j' : re.compile(f'(TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*).*{year}'),
-                'cr_2e_j' : re.compile(f'(TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*).*{year}'),
+                'cr_1m_j' : re.compile(f'(Top_FXFX.*|Diboson.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|.*WJetsToLNu.*HT.*).*{year}'),
+                'cr_1e_j' : re.compile(f'(Top_FXFX.*|Diboson.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|.*WJetsToLNu.*HT.*|GJets_DR.*HT.*).*{year}'),
+                'cr_2m_j' : re.compile(f'(Top_FXFX.*|Diboson.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*).*{year}'),
+                'cr_2e_j' : re.compile(f'(Top_FXFX.*|Diboson.*|QCD_HT.*|DYJetsToLL_M-50_HT_MLM)_{year}'),
                 'cr_g_j' : re.compile(f'(GJets_DR.*HT.*|QCD_data.*|WJetsToLNu.*HT.*).*{year}'),
             }
 

--- a/bucoffea/plot/studies/lo_vs_nlo/lo_vs_nlo.py
+++ b/bucoffea/plot/studies/lo_vs_nlo/lo_vs_nlo.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import argparse
 import os
 import re
 import sys
@@ -10,8 +11,8 @@ from bucoffea.plot.style import plot_settings
 from bucoffea.plot.util import merge_datasets, merge_extensions, scale_xs_lumi
 
 
-def plot(inpath):
-        indir=os.path.abspath(inpath)
+def plot(args):
+        indir=os.path.abspath(args.inpath)
 
         # The processor output is stored in an
         # 'accumulator', which in our case is
@@ -23,7 +24,7 @@ def plot(inpath):
         # The merging only happens the first time
         # you run over a specific set of inputs.
         acc = dir_archive(
-                          inpath,
+                          args.inpath,
                           serialized=True,
                           compression=0,
                           memsize=1e3,
@@ -77,6 +78,8 @@ def plot(inpath):
             # Data / MC plots are made here
             # Loop over all regions
             for region in mc_lo.keys():
+                if not re.match(args.region, region):
+                        continue
                 # Make separate output direcotry for each region
                 outdir = f'./output/{os.path.basename(indir)}/{region}'
 
@@ -85,6 +88,8 @@ def plot(inpath):
 
                 # Loop over the distributions
                 for distribution in plotset.keys():
+                    if not re.match(args.distribution, distribution):
+                        continue
                     # Load from cache
                     if not (distribution in merged):
                         acc.load(distribution)
@@ -116,9 +121,17 @@ def plot(inpath):
 
                     except KeyError:
                         continue
+def commandline():
+    parser = argparse.ArgumentParser(prog='Plotter.')
+    parser.add_argument('inpath', type=str, help='Input folder to use.')
+    parser.add_argument('--region', type=str, default='.*', help='Region to plot.')
+    parser.add_argument('--distribution', type=str, default='.*', help='Distribution to plot.')
+    args = parser.parse_args()
+    return args
+
 def main():
-    inpath = sys.argv[1]
-    plot(inpath)
+    args = commandline()
+    plot(args)
 
 
 if __name__ == "__main__":

--- a/bucoffea/plot/studies/lo_vs_nlo/lo_vs_nlo_vbf.py
+++ b/bucoffea/plot/studies/lo_vs_nlo/lo_vs_nlo_vbf.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import argparse
 import os
 import re
 import sys

--- a/bucoffea/plot/studies/lo_vs_nlo/lo_vs_nlo_vbf.py
+++ b/bucoffea/plot/studies/lo_vs_nlo/lo_vs_nlo_vbf.py
@@ -10,8 +10,8 @@ from bucoffea.plot.style import plot_settings
 from bucoffea.plot.util import merge_datasets, merge_extensions, scale_xs_lumi
 
 
-def plot(inpath):
-        indir=os.path.abspath(inpath)
+def plot(args):
+        indir=os.path.abspath(args.inpath)
 
         # The processor output is stored in an
         # 'accumulator', which in our case is
@@ -23,7 +23,7 @@ def plot(inpath):
         # The merging only happens the first time
         # you run over a specific set of inputs.
         acc = dir_archive(
-                          inpath,
+                          args.inpath,
                           serialized=True,
                           compression=0,
                           memsize=1e3
@@ -72,6 +72,8 @@ def plot(inpath):
             # Data / MC plots are made here
             # Loop over all regions
             for region in mc_lo.keys():
+                if not re.match(args.region, region):
+                        continue
                 ratio = True if region != 'sr_vbf' else False 
                 # Make separate output direcotry for each region
                 outdir = f'./output/{os.path.basename(indir)}/{region}'
@@ -80,6 +82,8 @@ def plot(inpath):
 
                 # Loop over the distributions
                 for distribution in plotset.keys():
+                    if not re.match(args.distribution, distribution):
+                        continue
                     # Load from cache
                     if not distribution in merged:
                         acc.load(distribution)
@@ -113,9 +117,17 @@ def plot(inpath):
                     except KeyError:
                         continue
 
+def commandline():
+    parser = argparse.ArgumentParser(prog='Plotter.')
+    parser.add_argument('inpath', type=str, help='Input folder to use.')
+    parser.add_argument('--region', type=str, default='.*', help='Region to plot.')
+    parser.add_argument('--distribution', type=str, default='.*', help='Distribution to plot.')
+    args = parser.parse_args()
+    return args
+
 def main():
-    inpath = sys.argv[1]
-    plot(inpath)
+    args = commandline()
+    plot(args)
 
 
 if __name__ == "__main__":

--- a/bucoffea/plot/studies/lo_vs_nlo/lo_vs_nlo_vbf.py
+++ b/bucoffea/plot/studies/lo_vs_nlo/lo_vs_nlo_vbf.py
@@ -56,11 +56,11 @@ def plot(inpath):
             # Match datasets by regular expressions
             # Here for LO V samples (HT binned)
             mc_lo = {
-                'sr_vbf' : re.compile(f'(ZJetsToNuNu.*|EW.*|TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|.*WJetsToLNu.*HT.*).*{year}'),
-                'cr_1m_vbf' : re.compile(f'(EW.*|TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|.*WJetsToLNu.*HT.*).*{year}'),
-                'cr_1e_vbf' : re.compile(f'(EW.*|TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|.*WJetsToLNu.*HT.*).*{year}'),
-                'cr_2m_vbf' : re.compile(f'(EW.*|TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*).*{year}'),
-                'cr_2e_vbf' : re.compile(f'(EW.*|TTJets.*FXFX.*|Diboson.*|ST.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*).*{year}'),
+                'sr_vbf' : re.compile(f'(ZJetsToNuNu.*|EW.*|Top_FXFX.*|Diboson.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|.*WJetsToLNu.*HT.*).*{year}'),
+                'cr_1m_vbf' : re.compile(f'(EW.*|Top_FXFX.*|Diboson.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|.*WJetsToLNu.*HT.*).*{year}'),
+                'cr_1e_vbf' : re.compile(f'(EW.*|Top_FXFX.*|Diboson.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*|.*WJetsToLNu.*HT.*).*{year}'),
+                'cr_2m_vbf' : re.compile(f'(EW.*|Top_FXFX.*|Diboson.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*).*{year}'),
+                'cr_2e_vbf' : re.compile(f'(EW.*|Top_FXFX.*|Diboson.*|QCD_HT.*|.*DYJetsToLL_M-50_HT_MLM.*).*{year}'),
                 'cr_g_vbf' : re.compile(f'(GJets_(DR-0p4|SM).*|QCD_HT.*|WJetsToLNu.*HT.*).*{year}'),
             }
 

--- a/bucoffea/plot/util.py
+++ b/bucoffea/plot/util.py
@@ -146,6 +146,7 @@ def merge_extensions(histogram, acc, reweight_pu=True, noscale=False):
             if reweight_pu:
                 sumw_pileup[base] += acc['sumw_pileup'][d]
                 nevents[base] += acc['nevents'][d]
+
     histogram = histogram.group("dataset", hist.Cat("dataset", "Primary dataset"), mapping)
 
     if not noscale:
@@ -219,10 +220,9 @@ def merge_datasets(histogram):
         'DYJetsToLL_M-50_HT_MLM_{year}' : 'DYJetsToLL_M-50_HT-(\d+)to.*-MLM_{year}',
         'WJetsToLNu_HT_MLM_{year}' : 'WJetsToLNu_HT-(\d+)To.*-MLM_{year}',
 
-        'TTJets-FXFX_{year}' : 'TTJets-amcatnloFXFX_{year}',
-        'TTJets-MLM_{year}' : 'TTJets-MLM_{year}',
-        'TT_pow_{year}' : 'TTTo.*pow.*{year}',
-        'ST_{year}' : 'ST.*{year}',
+        'Top_FXFX_{year}' : '(TTJets-amcatnloFXFX|ST.*)_{year}',
+        'Top_MLM_{year}' : '(TTJets-amcatnloFXFX|ST.*)_{year}',
+        'TT_pow_{year}' : '(TTTo.*pow|ST).*{year}',
 
         'QCD_HT_{year}' : 'QCD_HT.*_{year}',
 

--- a/bucoffea/plot/util.py
+++ b/bucoffea/plot/util.py
@@ -221,7 +221,7 @@ def merge_datasets(histogram):
         'WJetsToLNu_HT_MLM_{year}' : 'WJetsToLNu_HT-(\d+)To.*-MLM_{year}',
 
         'Top_FXFX_{year}' : '(TTJets-amcatnloFXFX|ST.*)_{year}',
-        'Top_MLM_{year}' : '(TTJets-amcatnloFXFX|ST.*)_{year}',
+        'Top_MLM_{year}' : '(TTJets.*MLM.*|ST.*)_{year}',
         'TT_pow_{year}' : '(TTTo.*pow|ST).*{year}',
 
         'QCD_HT_{year}' : 'QCD_HT.*_{year}',


### PR DESCRIPTION
This is a follow-up to #171

Previously, we treated single top (ST) and ttbar datasets (TT) independently in our plots. This is valid, but not compatible with our limit workflow, which uses a combined "top" dataset. To be consistent everywhere, I changed the dataset merging to automatically merge ST and TT, and propagated this change to the limit scripts, as well as to the lo_vs_nlo plotters.

In an unrelated changed, I also added commandline arguments to the plotters to allow the user to select what plots are made, e.g.

```
./lo_vs_nlo.py /path/to/input --region 'cr_(\d)m_j' --distribution 'muon_pt.*'
```

@siqiyyyy @alpakpinar please take a look