### PR TITLE
VBF: remove MT cut, add ele met 80

### DIFF
--- a/bucoffea/config/vbfhinv.yaml
+++ b/bucoffea/config/vbfhinv.yaml
@@ -34,10 +34,10 @@ default:
           min: 60
           max: 120
       singlemu:
-        mt : 160
+        mt : 9999
       singleel:
-        mt: 160
-        met: 50
+        mt: 9999
+        met: 80
   tau:
     cuts:
       pt: 20

--- a/bucoffea/vbfhinv/definitions.py
+++ b/bucoffea/vbfhinv/definitions.py
@@ -251,7 +251,7 @@ def vbfhinv_regions(cfg):
     regions['cr_2m_vbf'] = cr_2m_cuts
 
     # Single muon CR
-    cr_1m_cuts = ['trig_met','one_muon', 'at_least_one_tight_mu',  'veto_ele', 'mt_mu'] + common_cuts[1:]
+    cr_1m_cuts = ['trig_met','one_muon', 'at_least_one_tight_mu',  'veto_ele'] + common_cuts[1:]
     cr_1m_cuts.remove('veto_muo')
     regions['cr_1m_vbf'] = cr_1m_cuts 
 
@@ -261,7 +261,7 @@ def vbfhinv_regions(cfg):
     regions['cr_2e_vbf'] = cr_2e_cuts 
 
     # Single electron CR
-    cr_1e_cuts = ['trig_ele','one_electron', 'at_least_one_tight_el', 'veto_muo','met_el','mt_el'] + common_cuts[1:]
+    cr_1e_cuts = ['trig_ele','one_electron', 'at_least_one_tight_el', 'veto_muo','met_el'] + common_cuts[1:]
     # cr_1e_cuts.remove('veto_ele')
     regions['cr_1e_vbf'] =  cr_1e_cuts
 


### PR DESCRIPTION
In VBF, we decided to 

a) remove the MT cut from both single electron and single muon regions.

b) Increase the MET threshold for the single electron region from 50 to 80 GeV.

@alpakpinar please review