### PR TITLE
2020 04 14 fake met selection

### DIFF
--- a/bucoffea/vbfhinv/definitions.py
+++ b/bucoffea/vbfhinv/definitions.py
@@ -36,8 +36,7 @@ def vbfhinv_accumulator(cfg):
 
     jet_mass_ax = Bin("mass", r"$M_{jet}$ (GeV)", 100,0,300)
 
-    dpfcalo_ax = Bin("dpfcalo_sr", r"$(PFMET-CaloMET) / PFMET$", 20, -1, 1)
-    dpfcalo_ax = Bin("dpfcalo_cr", r"$(PFMET-CaloMET) / Recoil$", 20, -1, 1)
+    dpfcalo_ax = Bin("dpfcalo", r"$(PFMET-CaloMET) / Recoil$", 20, -1, 1)
     btag_ax = Bin("btag", r"B tag discriminator", 20, 0, 1)
     multiplicity_ax = Bin("multiplicity", r"multiplicity", 10, -0.5, 9.5)
     nconst_ax = Bin("nconst", r"Number of constituents", 25, -0.5, 99.5)
@@ -121,7 +120,8 @@ def vbfhinv_accumulator(cfg):
     items["recoil_mjj"] = Hist("Counts", dataset_ax, region_ax, recoil_ax, mjj_ax)
     items["photon_eta_phi"] = Hist("Counts", dataset_ax, region_ax, eta_ax_coarse, phi_ax_coarse)
 
-    items["dpfcalo"] = Hist("Counts", dataset_ax, region_ax, dpfcalo_ax)
+    items["dpfcalo_cr"] = Hist("Counts", dataset_ax, region_ax, dpfcalo_ax)
+    items["dpfcalo_sr"] = Hist("Counts", dataset_ax, region_ax, dpfcalo_ax)
     items["dphijm"] = Hist("min(4 leading jets, MET)", dataset_ax, region_ax, dphi_ax)
     items["dphijr"] = Hist("min(4 leading jets, Recoil)", dataset_ax, region_ax, dphi_ax)
 

--- a/bucoffea/vbfhinv/definitions.py
+++ b/bucoffea/vbfhinv/definitions.py
@@ -202,7 +202,6 @@ def vbfhinv_regions(cfg):
         'veto_ele',
         'veto_muo',
         'filt_met',
-        'hemveto',
         'mindphijr',
         'recoil',
         'two_jets',
@@ -210,6 +209,7 @@ def vbfhinv_regions(cfg):
         'leadak4_id',
         'trailak4_pt_eta',
         'trailak4_id',
+        'hornveto',
         'hemisphere',
         'mjj',
         'dphijj',
@@ -224,7 +224,7 @@ def vbfhinv_regions(cfg):
     regions['inclusive'] = ['inclusive']
 
     # Signal regions (v = mono-V, j = mono-jet)
-    regions['sr_vbf'] = ['trig_met'] + common_cuts
+    regions['sr_vbf'] = ['trig_met','metphihemextveto'] + common_cuts
 
     # For sync mode
     if cfg.RUN.SYNC:

--- a/bucoffea/vbfhinv/definitions.py
+++ b/bucoffea/vbfhinv/definitions.py
@@ -209,7 +209,6 @@ def vbfhinv_regions(cfg):
         'leadak4_id',
         'trailak4_pt_eta',
         'trailak4_id',
-        'hornveto',
         'hemisphere',
         'mjj',
         'dphijj',
@@ -224,7 +223,7 @@ def vbfhinv_regions(cfg):
     regions['inclusive'] = ['inclusive']
 
     # Signal regions (v = mono-V, j = mono-jet)
-    regions['sr_vbf'] = ['trig_met','metphihemextveto'] + common_cuts
+    regions['sr_vbf'] = ['trig_met','metphihemextveto','hornveto'] + common_cuts
 
     # For sync mode
     if cfg.RUN.SYNC:

--- a/bucoffea/vbfhinv/definitions.py
+++ b/bucoffea/vbfhinv/definitions.py
@@ -216,14 +216,13 @@ def vbfhinv_regions(cfg):
         'veto_photon',
         'veto_tau',
         'veto_b',
-        'dpfcalo'
     ]
 
     regions = {}
     regions['inclusive'] = ['inclusive']
 
     # Signal regions (v = mono-V, j = mono-jet)
-    regions['sr_vbf'] = ['trig_met','metphihemextveto','hornveto'] + common_cuts
+    regions['sr_vbf'] = ['trig_met','metphihemextveto','hornveto'] + common_cuts + ['dpfcalo_sr']
 
     # For sync mode
     if cfg.RUN.SYNC:
@@ -244,28 +243,29 @@ def vbfhinv_regions(cfg):
         ]
 
     # Dimuon CR
-    cr_2m_cuts = ['trig_met','two_muons', 'at_least_one_tight_mu', 'dimuon_mass', 'veto_ele', 'dimuon_charge'] + common_cuts[1:]
+    cr_2m_cuts = ['trig_met','two_muons', 'at_least_one_tight_mu', 'dimuon_mass', 'veto_ele', 'dimuon_charge'] + common_cuts[1:] + ['dpfcalo_cr']
+
     cr_2m_cuts.remove('veto_muo')
 
     regions['cr_2m_vbf'] = cr_2m_cuts
 
     # Single muon CR
-    cr_1m_cuts = ['trig_met','one_muon', 'at_least_one_tight_mu',  'veto_ele'] + common_cuts[1:]
+    cr_1m_cuts = ['trig_met','one_muon', 'at_least_one_tight_mu',  'veto_ele'] + common_cuts[1:] + ['dpfcalo_cr']
     cr_1m_cuts.remove('veto_muo')
     regions['cr_1m_vbf'] = cr_1m_cuts 
 
     # Dielectron CR
-    cr_2e_cuts = ['trig_ele','two_electrons', 'at_least_one_tight_el', 'dielectron_mass', 'veto_muo', 'dielectron_charge'] + common_cuts[2:]
+    cr_2e_cuts = ['trig_ele','two_electrons', 'at_least_one_tight_el', 'dielectron_mass', 'veto_muo', 'dielectron_charge'] + common_cuts[2:] + ['dpfcalo_cr']
     # cr_2e_cuts.remove('veto_ele')
     regions['cr_2e_vbf'] = cr_2e_cuts 
 
     # Single electron CR
-    cr_1e_cuts = ['trig_ele','one_electron', 'at_least_one_tight_el', 'veto_muo','met_el'] + common_cuts[1:]
+    cr_1e_cuts = ['trig_ele','one_electron', 'at_least_one_tight_el', 'veto_muo','met_el'] + common_cuts[1:] + ['dpfcalo_cr']
     # cr_1e_cuts.remove('veto_ele')
     regions['cr_1e_vbf'] =  cr_1e_cuts
 
     # Photon CR
-    cr_g_cuts = ['trig_photon', 'one_photon', 'at_least_one_tight_photon','photon_pt'] + common_cuts
+    cr_g_cuts = ['trig_photon', 'one_photon', 'at_least_one_tight_photon','photon_pt'] + common_cuts + ['dpfcalo_cr']
     cr_g_cuts.remove('veto_photon')
 
     regions['cr_g_vbf'] = cr_g_cuts

--- a/bucoffea/vbfhinv/definitions.py
+++ b/bucoffea/vbfhinv/definitions.py
@@ -36,7 +36,8 @@ def vbfhinv_accumulator(cfg):
 
     jet_mass_ax = Bin("mass", r"$M_{jet}$ (GeV)", 100,0,300)
 
-    dpfcalo_ax = Bin("dpfcalo", r"$(CaloMET-PFMET) / Recoil$", 20, -1, 1)
+    dpfcalo_ax = Bin("dpfcalo_sr", r"$(PFMET-CaloMET) / PFMET$", 20, -1, 1)
+    dpfcalo_ax = Bin("dpfcalo_cr", r"$(PFMET-CaloMET) / Recoil$", 20, -1, 1)
     btag_ax = Bin("btag", r"B tag discriminator", 20, 0, 1)
     multiplicity_ax = Bin("multiplicity", r"multiplicity", 10, -0.5, 9.5)
     nconst_ax = Bin("nconst", r"Number of constituents", 25, -0.5, 99.5)

--- a/bucoffea/vbfhinv/vbfhinvProcessor.py
+++ b/bucoffea/vbfhinv/vbfhinvProcessor.py
@@ -292,6 +292,7 @@ class vbfhinvProcessor(processor.ProcessorABC):
         # Recoil
         df['recoil_pt'], df['recoil_phi'] = recoil(met_pt,met_phi, electrons, muons, photons)
         df["dPFCalo"] = (met_pt - df["CaloMET_pt"]) / df["recoil_pt"]
+        df["dPFTk"] = (met_pt - df["TkMET_pt"]) / df["recoil_pt"]
         df["minDPhiJetRecoil"] = min_dphi_jet_met(ak4, df['recoil_phi'], njet=4, ptmin=30, etamax=5.0)
         df["minDPhiJetMet"] = min_dphi_jet_met(ak4, met_phi, njet=4, ptmin=30, etamax=5.0)
         selection = processor.PackedSelection()

--- a/bucoffea/vbfhinv/vbfhinvProcessor.py
+++ b/bucoffea/vbfhinv/vbfhinvProcessor.py
@@ -609,7 +609,8 @@ class vbfhinvProcessor(processor.ProcessorABC):
             ezfill('ak4_btag', btag=btag[mask].flatten(), weight=w_btag )
 
             # MET
-            ezfill('dpfcalo',            dpfcalo=df["dPFCalo"][mask],       weight=rweight[mask] )
+            ezfill('dpfcalo_cr',            dpfcalo=df["dPFCaloCR"][mask],       weight=rweight[mask] )
+            ezfill('dpfcalo_sr',            dpfcalo=df["dPFCaloSR"][mask],       weight=rweight[mask] )
             ezfill('met',                met=met_pt[mask],            weight=rweight[mask] )
             ezfill('met_phi',            phi=met_phi[mask],           weight=rweight[mask] )
             ezfill('recoil',             recoil=df["recoil_pt"][mask],      weight=rweight[mask] )


### PR DESCRIPTION
The following changes are made:
* In both 2017 and 2018, events are rejected from the signal region if they have (PFMet-TkMet)/ PFMet > 0.8 and one of two leading jets is located in the horn-region.
* In 2018, the old hemveto is removed. Instead, all candidates that are within the HEM eta-phi region are ignored for the event selection. Additionally, events in the SR are rejected if they have the MET phi pointing towards the HEM region.
* Separate versions of the dpfcalo cut are defined for signal and control regions. This is meant to deal with the veto weight version of the signal region, where the vetos on leptons are removed. In that case, `recoil` includes these leptons, which is not what we want, and we use `met` directly instead.