### PR TITLE
2020 07 07 nojer

### DIFF
--- a/bucoffea/config/monojet.yaml
+++ b/bucoffea/config/monojet.yaml
@@ -31,6 +31,12 @@ default:
       singleel:
         mt: 160
         met: 50
+  ak4:
+    jer: false
+  ak8:
+    jer: false
+  met:
+    jer: false
   tau:
     cuts:
       pt: 18
@@ -166,7 +172,7 @@ default:
     save:
       passing: False
       prescale: 1
-      tree: False 
+      tree: False
       treeregions: "((sr|cr_.*)_j|inclusive)$"
     kinematics:
       save: False

--- a/bucoffea/config/vbfhinv.yaml
+++ b/bucoffea/config/vbfhinv.yaml
@@ -39,11 +39,11 @@ default:
         mt: 9999
         met: 80
   ak4:
-    jer: false
+    jer: true
   ak8:
-    jer: false
+    jer: true
   met:
-    jer: false
+    jer: true
   tau:
     cuts:
       pt: 20

--- a/bucoffea/config/vbfhinv.yaml
+++ b/bucoffea/config/vbfhinv.yaml
@@ -38,6 +38,12 @@ default:
       singleel:
         mt: 9999
         met: 80
+  ak4:
+    jer: false
+  ak8:
+    jer: false
+  met:
+    jer: false
   tau:
     cuts:
       pt: 20

--- a/bucoffea/monojet/definitions.py
+++ b/bucoffea/monojet/definitions.py
@@ -429,11 +429,11 @@ def setup_candidates(df, cfg):
 
     ak8 = JaggedCandidateArray.candidatesfromcounts(
         df['nFatJet'],
-        pt=df[f'FatJet_pt{jes_suffix}'],
+        pt=df[f'FatJet_pt{jes_suffix}'] if df['is_data'] else df[f'FatJet_pt{jes_suffix}']/df['FatJet_corr_JER'],
         eta=df['FatJet_eta'],
         abseta=np.abs(df['FatJet_eta']),
         phi=df['FatJet_phi'],
-        mass=df[f'FatJet_msoftdrop{jes_suffix}'],
+        mass=df[f'FatJet_msoftdrop{jes_suffix}'] if df['is_data'] else df[f'FatJet_msoftdrop{jes_suffix}']/df['FatJet_corr_JER'],
         tightId=(df['FatJet_jetId']&2) == 2, # Tight
         csvv2=df["FatJet_btagCSVV2"],
         deepcsv=df['FatJet_btagDeepB'],

--- a/bucoffea/monojet/definitions.py
+++ b/bucoffea/monojet/definitions.py
@@ -269,7 +269,7 @@ def setup_candidates(df, cfg):
     else:
         # MC, all years
         jes_suffix = '_nom'
-        jes_suffix_met = '_jer'
+        jes_suffix_met = '_nom'
 
     muons = JaggedCandidateArray.candidatesfromcounts(
         df['nMuon'],
@@ -373,7 +373,7 @@ def setup_candidates(df, cfg):
 
     ak4 = JaggedCandidateArray.candidatesfromcounts(
         df['nJet'],
-        pt=df[f'Jet_pt{jes_suffix}'],
+        pt=df[f'Jet_pt{jes_suffix}'] if df['is_data'] else df[f'Jet_pt{jes_suffix}']/df['Jet_corr_JER'],
         eta=df['Jet_eta'],
         abseta=np.abs(df['Jet_eta']),
         phi=df['Jet_phi'],

--- a/bucoffea/monojet/definitions.py
+++ b/bucoffea/monojet/definitions.py
@@ -383,7 +383,7 @@ def setup_candidates(df, cfg):
         mass=np.zeros_like(df['Jet_pt']),
         looseId=(df['Jet_jetId']&2) == 2, # bitmask: 1 = loose, 2 = tight, 3 = tight + lep veto
         tightId=(df['Jet_jetId']&2) == 2, # bitmask: 1 = loose, 2 = tight, 3 = tight + lep veto
-        puid=((df['Jet_puId']&2>0) | (df[f'Jet_pt{jes_suffix}']>50)), # medium pileup jet ID
+        puid=((df['Jet_puId']&2>0) | ((df[f'Jet_pt{jes_suffix}'] if (df['is_data'] or cfg.AK4.JER) else df[f'Jet_pt{jes_suffix}']/df['Jet_corr_JER'])>50)), # medium pileup jet ID
         csvv2=df["Jet_btagCSVV2"],
         deepcsv=df['Jet_btagDeepB'],
         nef=df['Jet_neEmEF'],

--- a/bucoffea/monojet/definitions.py
+++ b/bucoffea/monojet/definitions.py
@@ -269,7 +269,10 @@ def setup_candidates(df, cfg):
     else:
         # MC, all years
         jes_suffix = '_nom'
-        jes_suffix_met = '_nom'
+        if cfg.MET.JER:
+            jes_suffix_met = '_jer'
+        else:
+            jes_suffix_met = '_nom'
 
     muons = JaggedCandidateArray.candidatesfromcounts(
         df['nMuon'],
@@ -373,7 +376,7 @@ def setup_candidates(df, cfg):
 
     ak4 = JaggedCandidateArray.candidatesfromcounts(
         df['nJet'],
-        pt=df[f'Jet_pt{jes_suffix}'] if df['is_data'] else df[f'Jet_pt{jes_suffix}']/df['Jet_corr_JER'],
+        pt=df[f'Jet_pt{jes_suffix}'] if (df['is_data'] or cfg.AK4.JER) else df[f'Jet_pt{jes_suffix}']/df['Jet_corr_JER'],
         eta=df['Jet_eta'],
         abseta=np.abs(df['Jet_eta']),
         phi=df['Jet_phi'],
@@ -429,11 +432,11 @@ def setup_candidates(df, cfg):
 
     ak8 = JaggedCandidateArray.candidatesfromcounts(
         df['nFatJet'],
-        pt=df[f'FatJet_pt{jes_suffix}'] if df['is_data'] else df[f'FatJet_pt{jes_suffix}']/df['FatJet_corr_JER'],
+        pt=df[f'FatJet_pt{jes_suffix}'] if (df['is_data'] or cfg.AK8.JER) else df[f'FatJet_pt{jes_suffix}']/df['FatJet_corr_JER'],
         eta=df['FatJet_eta'],
         abseta=np.abs(df['FatJet_eta']),
         phi=df['FatJet_phi'],
-        mass=df[f'FatJet_msoftdrop{jes_suffix}'] if df['is_data'] else df[f'FatJet_msoftdrop{jes_suffix}']/df['FatJet_corr_JER'],
+        mass=df[f'FatJet_msoftdrop{jes_suffix}'] if (df['is_data'] or cfg.AK8.JER) else df[f'FatJet_msoftdrop{jes_suffix}']/df['FatJet_corr_JER'],
         tightId=(df['FatJet_jetId']&2) == 2, # Tight
         csvv2=df["FatJet_btagCSVV2"],
         deepcsv=df['FatJet_btagDeepB'],


### PR DESCRIPTION
This PR makes the use of JER corrections configurable. Separate config flags are use to turn on/off JER for AK4, AK8 jets and MET. For now, JER is turned OFF for monojet/v, but left ON for VBF. For VBF, we ultimately also want to turn it off, but should coordinate with collaborators first.

@alpakpinar could you please check that I'm using all the right branches here? Thanks!