### PR TITLE
Fix numba version for setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ gitpython
 tabulate
 klepto
 pycairo>=1.18.2
+numba==0.50.1


### PR DESCRIPTION
Hey @AndreasAlbert , @siqiyyyy 

I had an issue on my latest buexec submission, regarding version conflicts. I think the required numba version is updated to 0.51.0, and this caused an issue for me. For now, I fixed the numba requirement to be ==0.50.1, the version that was being used before. With this update, jobs seemed to work fine for me. I'm not sure if this is the best approach to this, but just wanted to bring up the issue, thanks! 

Alp   