### PR TITLE
Update to DeepTau

### DIFF
--- a/bucoffea/config/monojet.yaml
+++ b/bucoffea/config/monojet.yaml
@@ -42,8 +42,8 @@ default:
       pt: 18
       eta: 2.3
     branch:
-      id: Tau_idDecayMode
-      iso: Tau_idMVAoldDM2017v2
+      id: Tau_idDecayModeNewDMs
+      iso: Tau_idDeepTau2017v2p1VSjet
   photon:
     cuts:
       loose:
@@ -53,7 +53,7 @@ default:
         pt: 230
         pttrig: 230
     branch:
-      id: Photon_cutBasedBitmap
+      id: Photon_cutBased_Fall17V1Bitmap
       idv7: Photon_cutBased
   muon:
     cuts:
@@ -254,8 +254,8 @@ era2016:
       id: Photon_cutBased
   tau:
     branch:
-      id: Tau_idDecayMode
-      iso: Tau_idMVAoldDM
+      id: Tau_idDecayModeNewDMs
+      iso: Tau_idDeepTau2017v2p1VSjet
   sf:
     deepcsv:
       file: data/sf/btag/DeepCSV_102XSF_WP_V1.csv

--- a/bucoffea/config/monojet.yaml
+++ b/bucoffea/config/monojet.yaml
@@ -42,8 +42,8 @@ default:
       pt: 18
       eta: 2.3
     branch:
-      id: Tau_idDecayModeNewDMs
-      iso: Tau_idDeepTau2017v2p1VSjet
+      id: Tau_idDecayMode
+      iso: Tau_idMVAoldDM2017v2
   photon:
     cuts:
       loose:
@@ -53,7 +53,7 @@ default:
         pt: 230
         pttrig: 230
     branch:
-      id: Photon_cutBased_Fall17V1Bitmap
+      id: Photon_cutBasedBitmap
       idv7: Photon_cutBased
   muon:
     cuts:
@@ -254,8 +254,8 @@ era2016:
       id: Photon_cutBased
   tau:
     branch:
-      id: Tau_idDecayModeNewDMs
-      iso: Tau_idDeepTau2017v2p1VSjet
+      id: Tau_idDecayMode
+      iso: Tau_idMVAoldDM
   sf:
     deepcsv:
       file: data/sf/btag/DeepCSV_102XSF_WP_V1.csv

--- a/bucoffea/config/vbfhinv.yaml
+++ b/bucoffea/config/vbfhinv.yaml
@@ -39,11 +39,11 @@ default:
         mt: 9999
         met: 80
   ak4:
-    jer: true
+    jer: false
   ak8:
-    jer: true
+    jer: false
   met:
-    jer: true
+    jer: false
   tau:
     cuts:
       pt: 20
@@ -60,7 +60,8 @@ default:
         pt: 230
         pttrig: 230
     branch: # No eta cut here bc we use "isScEtaEB"
-      id: Photon_cutBased_Fall17V1Bitmap
+      id: Photon_cutBasedBitmap
+      idv7: Photon_cutBased
   muon:
     cuts:
       tight:
@@ -279,7 +280,7 @@ era2016:
       id: Electron_cutBased_Sum16
   photon:
     branch:
-      id: Photon_cutBased17Bitmap
+      id: Photon_cutBased
   tau:
     branch:
       id: Tau_idDecayModeNewDMs

--- a/bucoffea/config/vbfhinv.yaml
+++ b/bucoffea/config/vbfhinv.yaml
@@ -49,8 +49,8 @@ default:
       pt: 20
       eta: 2.3
     branch:
-      id: Tau_idDecayMode
-      iso: Tau_idMVAoldDM2017v2
+      id: Tau_idDecayModeNewDMs
+      iso: Tau_idDeepTau2017v2p1VSjet
   photon:
     cuts:
       loose:
@@ -60,7 +60,7 @@ default:
         pt: 230
         pttrig: 230
     branch: # No eta cut here bc we use "isScEtaEB"
-      id: Photon_cutBasedBitmap
+      id: Photon_cutBased_Fall17V1Bitmap
   muon:
     cuts:
       tight:
@@ -282,8 +282,8 @@ era2016:
       id: Photon_cutBased17Bitmap
   tau:
     branch:
-      id: Tau_idDecayMode
-      iso: Tau_idMVAoldDM
+      id: Tau_idDecayModeNewDMs
+      iso: Tau_idDeepTau2017v2p1VSjet
   sf:
     ele_reco:
       histogram: EGamma_SF2D

--- a/bucoffea/execute/dataset_definitions.py
+++ b/bucoffea/execute/dataset_definitions.py
@@ -199,7 +199,7 @@ def files_from_eos(regex):
                 fileset[key] = fileset_16jul[key]
     elif 'lpc' in host:
         topdir = '/eos/uscms/store/user/aandreas/nanopost/'
-        tag = '05Jun20v5'
+        tag = '09Jun20v7'
         fileset = find_files_eos(pjoin(topdir, tag), regex)
 
     return fileset

--- a/bucoffea/monojet/definitions.py
+++ b/bucoffea/monojet/definitions.py
@@ -336,7 +336,6 @@ def setup_candidates(df, cfg):
     if cfg.OVERLAP.ELECTRON.MUON.CLEAN:
         electrons = electrons[object_overlap(electrons, muons, dr=cfg.OVERLAP.ELECTRON.MUON.DR)]
 
-
     taus = JaggedCandidateArray.candidatesfromcounts(
         df['nTau'],
         pt=df['Tau_pt'],

--- a/bucoffea/monojet/definitions.py
+++ b/bucoffea/monojet/definitions.py
@@ -351,7 +351,7 @@ def setup_candidates(df, cfg):
     taus = taus[ (taus.decaymode) \
                 & (taus.pt > cfg.TAU.CUTS.PT)\
                 & (taus.abseta < cfg.TAU.CUTS.ETA) \
-                & (taus.iso>=2)]
+                & ((taus.iso&2)==2)]
 
     if cfg.OVERLAP.TAU.MUON.CLEAN:
         taus = taus[object_overlap(taus, muons, dr=cfg.OVERLAP.TAU.MUON.DR)]

--- a/bucoffea/monojet/definitions.py
+++ b/bucoffea/monojet/definitions.py
@@ -351,7 +351,7 @@ def setup_candidates(df, cfg):
     taus = taus[ (taus.decaymode) \
                 & (taus.pt > cfg.TAU.CUTS.PT)\
                 & (taus.abseta < cfg.TAU.CUTS.ETA) \
-                & ((taus.iso&2)==2)]
+                & (taus.iso>=2)]
 
     if cfg.OVERLAP.TAU.MUON.CLEAN:
         taus = taus[object_overlap(taus, muons, dr=cfg.OVERLAP.TAU.MUON.DR)]


### PR DESCRIPTION
In this PR:
- Tau ID requirements updated to DeepTau
- Photon ID also updated to be compatible with nanoAODv7

Testing:
- Successfully ran on 2017 and 2018 VBF NanoAODv7 samples