### PR TITLE
Update on mjj bins for limit code

### DIFF
--- a/bucoffea/limit/legacy_vbf.py
+++ b/bucoffea/limit/legacy_vbf.py
@@ -90,7 +90,7 @@ def recoil_bins_2016():
              1020., 1090., 1160., 1250., 1400.]
 
 def mjj_bins_2016():
-    return [200., 400., 600., 900., 1200., 1500.,
+    return [200., 500., 800., 1200., 1600.,
             2000., 2750., 3500., 5000.]
 
 def legacy_limit_input_vbf(acc, outdir='./output', unblind=False):


### PR DESCRIPTION
Hey @AndreasAlbert, I found the mjj binnings I used for split JEC & limit histograms previously are slightly different. I believe split JEC ones are more recent, so I changed the ones in the limit input preparation code. Just wanted to bring this up and ask if we would want to merge this. Thanks!  