### PR TITLE
Fix on run_quick script

### DIFF
--- a/bucoffea/scripts/run_quick.py
+++ b/bucoffea/scripts/run_quick.py
@@ -19,7 +19,7 @@ def main():
 
     fileset = {
         "VBF_HToInvisible_M125_pow_pythia8_2017" : [
-            "root://cmsxrootd.fnal.gov//store/user/aandreas/nanopost/05Jun20v5/VBF_HToInvisible_M125_13TeV_TuneCP5_powheg_pythia8/VBF_HToInvisible_M125_pow_pythia8_2017/200605_233117/0000/tree_1.root"
+            "root://cmsxrootd.fnal.gov//store/user/aandreas/nanopost/03Sep20v7/VBF_HToInvisible_M125_13TeV_TuneCP5_powheg_pythia8/VBF_HToInvisible_M125_pow_pythia8_2017/200925_184136/0000/tree_1.root"
         ]
     }
 

--- a/bucoffea/scripts/run_quick.py
+++ b/bucoffea/scripts/run_quick.py
@@ -31,10 +31,10 @@ def main():
 
     if processor_class == 'monojet':
         from bucoffea.monojet import monojetProcessor
-        processorInstance = monojetProcessor(years[0])
+        processorInstance = monojetProcessor()
     elif processor_class == 'vbfhinv':
         from bucoffea.vbfhinv import vbfhinvProcessor
-        processorInstance = vbfhinvProcessor(years[0])
+        processorInstance = vbfhinvProcessor()
     elif processor_class == 'lhe':
         from bucoffea.gen.lheVProcessor import lheVProcessor
         processorInstance = lheVProcessor()


### PR DESCRIPTION
Hey @AndreasAlbert , I noticed this small issue by luck when I was testing out VBF processor on MET dataset.

I think the monojet and VBF processors are taking a wrong argument in this script, the year is provided for the "blind" argument. This causes the blinding of data in SR un-intentionally, because of the code in [1]. For now, I just removed this year argument from monojet and VBF processors when they're called, so that the default "blind" argument is applied. Let me know if this works or you want any more changes, thanks!  

[1]: https://github.com/bu-cms/bucoffea/blob/master/bucoffea/vbfhinv/vbfhinvProcessor.py#L474-L475    