### PR TITLE
Fix pycairo version to avoid version 1.20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pyyaml
 gitpython
 tabulate
 klepto
-pycairo>=1.18.2
+pycairo==1.19.1
 numba==0.50.1


### PR DESCRIPTION
pycairo version 1.20 seems to cause trouble during setup, this PR fixes the version to 1.19.1 (the version we previously were using) to avoid the issue. 