### PR TITLE
Fix the top regex to account for the name change in v7

### DIFF
--- a/bucoffea/plot/util.py
+++ b/bucoffea/plot/util.py
@@ -244,7 +244,7 @@ def merge_datasets(histogram):
         'DYJetsToLL_M-50_HT_MLM_{year}' : 'DYJetsToLL_M-50_HT-(\d+)to.*-MLM_{year}',
         'WJetsToLNu_HT_MLM_{year}' : 'WJetsToLNu_HT-(\d+)To.*-MLM_{year}',
 
-        'Top_FXFX_{year}' : '(TTJets-amcatnloFXFX|ST_((s|t)-channel|tW)_(anti)?top.*inclusiveDecays.*).*_{year}',
+        'Top_FXFX_{year}' : '(TTJets-amcatnloFXFX|ST_((s|t)-channel|tW)_(anti)?top.*[iI]nclusiveDecays.*).*_{year}',
         'Top_MLM_{year}' : '(TTJets.*MLM|ST_((s|t)-channel|tW)_(anti)?top).*_{year}',
         'TT_pow_{year}' : '(TTTo.*pow|ST).*{year}',
 


### PR DESCRIPTION
This PR contains a small fix to account for the name change in some of the top v7 samples:
"inclusiveDecays" -> "InclusiveDecays"