### PR TITLE
Top regex: Update to account for missing s-channel samples

### DIFF
--- a/bucoffea/plot/util.py
+++ b/bucoffea/plot/util.py
@@ -244,7 +244,7 @@ def merge_datasets(histogram):
         'DYJetsToLL_M-50_HT_MLM_{year}' : 'DYJetsToLL_M-50_HT-(\d+)to.*-MLM_{year}',
         'WJetsToLNu_HT_MLM_{year}' : 'WJetsToLNu_HT-(\d+)To.*-MLM_{year}',
 
-        'Top_FXFX_{year}' : '(TTJets-amcatnloFXFX|ST_((s|t)-channel|tW)_(anti)?top.*[iI]nclusiveDecays.*).*_{year}',
+        'Top_FXFX_{year}' : '(TTJets-amcatnloFXFX|ST_((s|t)-channel|tW)_(anti)?top).*_{year}',
         'Top_MLM_{year}' : '(TTJets.*MLM|ST_((s|t)-channel|tW)_(anti)?top).*_{year}',
         'TT_pow_{year}' : '(TTTo.*pow|ST).*{year}',
 


### PR DESCRIPTION
Hey @AndreasAlbert , this PR contains a small update to top regex in dataset merging scheme so that we take the missing s-channel samples into account as well. I tested the new regex and it captures the s-channel samples as well in it's current form, but if you think we can do with a better regex for this job I can also work on that. Thanks!