### PR TITLE
Add gen-checking for electrons and muons

### DIFF
--- a/bucoffea/config/monojet.yaml
+++ b/bucoffea/config/monojet.yaml
@@ -66,6 +66,7 @@ default:
         pt : 10
         eta : 2.4
         iso : 0.25
+    gencheck: False
   electron:
     cuts:
       tight:
@@ -82,6 +83,7 @@ default:
           endcap: 0.20
     branch:
       id: Electron_cutBased
+    gencheck: False
   btag:
     pt: 20
     eta: 2.4

--- a/bucoffea/config/vbfhinv.yaml
+++ b/bucoffea/config/vbfhinv.yaml
@@ -73,6 +73,7 @@ default:
         pt : 10
         eta : 2.4
         iso : 0.25
+    gencheck: True
   electron:
     cuts:
       tight:
@@ -89,6 +90,7 @@ default:
           endcap: 0.20
     branch:
       id: Electron_cutBased
+    gencheck: True
   btag:
     pt: 20
     eta: 2.5

--- a/bucoffea/helpers/weights.py
+++ b/bucoffea/helpers/weights.py
@@ -111,7 +111,7 @@ def get_veto_weights(df, cfg, evaluator, electrons, muons, taus, do_variations=F
 
 def gen_check_for_leptons(leptons, veto_weights, tau=False):
     '''
-    Return a mask containing information whether the event passed the lepton gen-matching or not.
+    Return the veto weights after checking if the leptons in the event are matched to a proper GEN-level lepton.
     For gen-matching on taus, use tau=True, otherwise use tau=False.
     '''
     # For muons and electrons, we require the gen particle flavor to be non-zero

--- a/bucoffea/monojet/definitions.py
+++ b/bucoffea/monojet/definitions.py
@@ -299,13 +299,17 @@ def setup_candidates(df, cfg):
         dz=df['Muon_dz']
     )
 
+    # For MC, add the matched gen-particle info for checking
+    if not df['is_data']:
+        kwargs = {'genpartflav' : df['Muon_genPartFlav']}
+        muons.add_attributes(**kwargs) 
+
     # All muons must be at least loose
     muons = muons[muons.looseId \
                     & (muons.iso < cfg.MUON.CUTS.LOOSE.ISO) \
                     & (muons.pt > cfg.MUON.CUTS.LOOSE.PT) \
                     & (muons.abseta<cfg.MUON.CUTS.LOOSE.ETA) \
                     ]
-
 
     electrons = JaggedCandidateArray.candidatesfromcounts(
         df['nElectron'],
@@ -323,6 +327,12 @@ def setup_candidates(df, cfg):
         dz=np.abs(df['Electron_dz']),
         barrel=np.abs(df['Electron_eta']+df['Electron_deltaEtaSC']) <= 1.4442
     )
+
+    # For MC, add the matched gen-particle info for checking
+    if not df['is_data']:
+        kwargs = {'genpartflav' : df['Electron_genPartFlav']}
+        electrons.add_attributes(**kwargs) 
+
     # All electrons must be at least loose
     pass_dxy = (electrons.barrel & (np.abs(electrons.dxy) < cfg.ELECTRON.CUTS.LOOSE.DXY.BARREL)) \
     | (~electrons.barrel & (np.abs(electrons.dxy) < cfg.ELECTRON.CUTS.LOOSE.DXY.ENDCAP))


### PR DESCRIPTION
Hey @AndreasAlbert , this PR contains the addition of GEN-checking for electrons and muons, in addition to taus. For electrons and muons, we basically look for "Lepton_genPartFlav != 0", otherwise we assign 0 weight. 

I shuffled the code a bit, moved the code that does the checking and assigning lepton weights to a helper function. Let me know what you think and if you want any changes to this, thanks!