### PR TITLE
Use nnlo xs for ST

### DIFF
--- a/bucoffea/data/datasets/xs/xs.yml
+++ b/bucoffea/data/datasets/xs/xs.yml
@@ -2592,19 +2592,19 @@ ST_s-channel_top_leptonDecays-PSweights_pow-pythia_2018:
   nlo: 2.0574
 ST_t-channel_antitop_4f_InclusiveDecays-pow-madspin_2018:
   gen: 69.09
-  nnlo: 83.0066
+  nnlo: 80.95
 ST_t-channel_antitop_4f_inclusiveDecays-powV2-madspin_2017:
   gen: 67.91
-  nnlo: 83.0066
+  nnlo: 80.95
 ST_t-channel_top_4f_InclusiveDecays-pow-madspin_2018:
   gen: 115.3
-  nnlo: 137.4581
+  nnlo: 136.02
 ST_t-channel_top_4f_inclusiveDecays-powV2-madspin_2017:
   gen: 113.3
-  nnlo: 137.4581
+  nnlo: 136.02
 ST_t-channel_top_4f_inclusiveDecays-powV2-madspin_new_pmx_2017:
   gen: 113.3
-  nnlo: 137.4581
+  nnlo: 136.02
 ST_tW_antitop_5f_inclusiveDecays-pow_2016:
   gen: 34.97
   nnlo: 35.85

--- a/bucoffea/data/datasets/xs/xs.yml
+++ b/bucoffea/data/datasets/xs/xs.yml
@@ -2544,56 +2544,52 @@ QCD_HT700to1000_GenJets5-MLM_2016:
   gen: 3029.0
 ST_s-channel_4f_hadronicDecays-amcatnlo_2017:
   gen: 11.24
+  nlo: 6.97632
 ST_s-channel_4f_hadronicDecays-mg_2018:
   gen: 11.24
+  nlo: 6.97632
 ST_s-channel_4f_hadronicDecays-mg_ext1_2018:
   gen: 11.24
+  nlo: 6.97632
 ST_s-channel_4f_leptonDecays-amcatnlo_2016:
   gen: 3.74
+  nlo: 3.3436799999999995
 ST_s-channel_4f_leptonDecays-amcatnlo_2017:
   gen: 3.74
-  nnlo: 10.32
+  nlo: 3.3436799999999995
 ST_s-channel_4f_leptonDecays-amcatnlo_2018:
   gen: 3.74
+  nlo: 3.3436799999999995
 ST_s-channel_4f_leptonDecays-mg_2018:
   gen: 3.74
-  nnlo: 1.1016749829959998
+  nlo: 3.3436799999999995
 ST_s-channel_4f_leptonDecays-mg_ext1_2018:
   gen: 3.74
-  nnlo: 1.1016749829959998
+  nlo: 3.3436799999999995
 ST_s-channel_4f_leptonDecays-mg_ext2_2018:
   gen: 3.74
+  nlo: 3.3436799999999995
 ST_s-channel_4f_leptonDecays_PSweights-amcatnlo_2016:
   gen: 3.74
+  nlo: 3.3436799999999995
 ST_s-channel_4f_leptonDecays_PSweights-amcatnlo_2017:
   gen: 3.74
-  nnlo: 10.32
+  nlo: 3.3436799999999995
 ST_s-channel_4f_leptonDecays_PSweights-amcatnlo_new_pmx_2017:
   gen: 3.74
-ST_s-channel_4f_leptonDecays_mtop1715-amcatnlo_2017:
-  gen: 3.824
-  nnlo: 10.32
-ST_s-channel_4f_leptonDecays_mtop1715-amcatnlo_2018:
-  gen: 3.824
-  nnlo: 10.32
-ST_s-channel_4f_leptonDecays_mtop1715_PSweights-amcatnlo_2017:
-  gen: 3.824
-  nnlo: 10.32
-ST_s-channel_4f_leptonDecays_mtop1715_PSweights-amcatnlo_2018:
-  gen: 3.824
-  nnlo: 10.32
+  nlo: 3.3436799999999995
 ST_s-channel_antitop_leptonDecays-PSweights_pow-pythia_2017:
   gen: 3.579
-  nnlo: 0.4260473698319999
+  nlo: 1.28628
 ST_s-channel_antitop_leptonDecays-PSweights_pow-pythia_2018:
   gen: 3.58
-  nnlo: 0.4260473698319999
+  nlo: 1.28628
 ST_s-channel_top_leptonDecays-PSweights_pow-pythia_2017:
   gen: 5.757
-  nnlo: 0.6756276131639999
+  nlo: 2.0574
 ST_s-channel_top_leptonDecays-PSweights_pow-pythia_2018:
   gen: 5.756
-  nnlo: 0.6756276131639999
+  nlo: 2.0574
 ST_t-channel_antitop_4f_InclusiveDecays-pow-madspin_2018:
   gen: 69.09
   nnlo: 83.0066

--- a/bucoffea/data/datasets/xs/xs.yml
+++ b/bucoffea/data/datasets/xs/xs.yml
@@ -2596,18 +2596,22 @@ ST_s-channel_top_leptonDecays-PSweights_pow-pythia_2018:
   nnlo: 0.6756276131639999
 ST_t-channel_antitop_4f_InclusiveDecays-pow-madspin_2018:
   gen: 69.09
+  nnlo: 83.0066
 ST_t-channel_antitop_4f_inclusiveDecays-powV2-madspin_2017:
   gen: 67.91
   nnlo: 83.0066
 ST_t-channel_top_4f_InclusiveDecays-pow-madspin_2018:
   gen: 115.3
+  nnlo: 137.4581
 ST_t-channel_top_4f_inclusiveDecays-powV2-madspin_2017:
   gen: 113.3
   nnlo: 137.4581
 ST_t-channel_top_4f_inclusiveDecays-powV2-madspin_new_pmx_2017:
   gen: 113.3
+  nnlo: 137.4581
 ST_tW_antitop_5f_inclusiveDecays-pow_2016:
   gen: 34.97
+  nnlo: 35.85
 ST_tW_antitop_5f_inclusiveDecays-pow_2017:
   gen: 34.97
   nnlo: 35.85

--- a/bucoffea/data/datasets/xs/xs.yml
+++ b/bucoffea/data/datasets/xs/xs.yml
@@ -2619,23 +2619,31 @@ ST_tW_antitop_5f_inclusiveDecays-pow_ext1_2018:
   nnlo: 35.85
 ST_tW_antitop_5f_inclusiveDecays_PSweights-pow_2016:
   gen: 34.97
+  nnlo: 35.85
 ST_tW_antitop_5f_inclusiveDecays_PSweights-pow_2017:
   gen: 34.97
   nnlo: 35.85
 ST_tW_antitop_5f_inclusiveDecaysdown-pow_2017:
   gen: 34.97
+  nnlo: 35.85
 ST_tW_antitop_5f_inclusiveDecaysdown-pow_2018:
   gen: 34.97
+  nnlo: 35.85
 ST_tW_antitop_5f_inclusiveDecaysdown_PSweights-pow_2017:
   gen: 34.97
+  nnlo: 35.85
 ST_tW_antitop_5f_inclusiveDecaysup-pow_2017:
   gen: 34.97
+  nnlo: 35.85
 ST_tW_antitop_5f_inclusiveDecaysup-pow_2018:
   gen: 34.97
+  nnlo: 35.85
 ST_tW_antitop_5f_inclusiveDecaysup_PSweights-pow_2017:
   gen: 34.97
+  nnlo: 35.85
 ST_tW_top_5f_inclusiveDecays-pow_2016:
   gen: 34.91
+  nnlo: 35.85
 ST_tW_top_5f_inclusiveDecays-pow_2017:
   gen: 34.91
   nnlo: 35.85
@@ -2647,27 +2655,37 @@ ST_tW_top_5f_inclusiveDecays-pow_ext1_2018:
   nnlo: 35.85
 ST_tW_top_5f_inclusiveDecays_PSweights-pow_2016:
   gen: 34.91
+  nnlo: 35.85
 ST_tW_top_5f_inclusiveDecays_PSweights-pow_2017:
   gen: 34.91
   nnlo: 35.85
 ST_tW_top_5f_inclusiveDecays_PSweights-pow_new_pmx_2017:
   gen: 34.91
+  nnlo: 35.85
 ST_tW_top_5f_inclusiveDecaysdown-pow_2017:
   gen: 34.91
+  nnlo: 35.85
 ST_tW_top_5f_inclusiveDecaysdown-pow_2018:
   gen: 34.91
+  nnlo: 35.85
 ST_tW_top_5f_inclusiveDecaysdown_PSweights-pow_2017:
   gen: 34.91
+  nnlo: 35.85
 ST_tW_top_5f_inclusiveDecaysdown_PSweights-pow_2018:
   gen: 34.91
+  nnlo: 35.85
 ST_tW_top_5f_inclusiveDecaysup-pow_2017:
   gen: 34.91
+  nnlo: 35.85
 ST_tW_top_5f_inclusiveDecaysup-pow_2018:
   gen: 34.91
+  nnlo: 35.85
 ST_tW_top_5f_inclusiveDecaysup_PSweights-pow_2017:
   gen: 34.91
+  nnlo: 35.85
 ST_tW_top_5f_inclusiveDecaysup_PSweights-pow_2018:
   gen: 34.91
+  nnlo: 35.85
 ScalarFirstGenLeptoquarkToQNu_Mlq-1000_Ylq-0p1_mg_2016:
   gen: 0.003615
 ScalarFirstGenLeptoquarkToQNu_Mlq-1000_Ylq-0p1_mg_2017:


### PR DESCRIPTION
@alpakpinar I'm harmozing the use of the higher order XS here for 2017 and 2018. Please check.