### PR TITLE
Require uproot-methods < 0.9.0 to avoid version conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ tabulate
 klepto
 pycairo==1.19.1
 numba==0.50.1
+uproot-methods<0.9.0


### PR DESCRIPTION
Hey @AndreasAlbert , @siqiyyyy , I recently got a version conflict regarding uproot and uproot-methods packages. I believe the uproot version got updated to 3.13.1 (previously I see 3.13.0), and uproot-methods got updated to 0.9.1. But then I see this warning in the log file (it crashes afterwards because of this incompatibility): 

"uproot 3.13.1 requires uproot-methods<0.9.0,>=0.7.0, but you'll have uproot-methods 0.9.1 which is incompatible."

I modified requirements.txt by adding uproot-methods<0.9.0, and it worked, do you think that would be a good way to solve this? I created this PR so that we can discuss this further and eventually come to a solution that we can merge, thanks!   