### PR TITLE
VBF: Add b-tag weights

### DIFF
--- a/bucoffea/config/vbfhinv.yaml
+++ b/bucoffea/config/vbfhinv.yaml
@@ -232,6 +232,7 @@ default:
         - 79123963
         - 51393664
     trigger_study: False
+    btag_study: False
     apply_categorized_sf: True
   triggers:
     ht:

--- a/bucoffea/config/vbfhinv.yaml
+++ b/bucoffea/config/vbfhinv.yaml
@@ -288,6 +288,8 @@ era2016:
       id: Tau_idDecayModeNewDMs
       iso: Tau_idDeepTau2017v2p1VSjet
   sf:
+    deepcsv:
+      file: data/sf/btag/DeepCSV_102XSF_WP_V1.csv
     ele_reco:
       histogram: EGamma_SF2D
       file: data/sf/egamma/2017_egammaEffi_txt_EGM2D_runBCDEF_passingRECO.root
@@ -419,6 +421,8 @@ era2017:
         medium: 0.4941
         tight: 0.8001
   sf:
+    deepcsv:
+      file: data/sf/btag/DeepCSV_94XSF_WP_V4_B_F.csv
     ele_reco:
       histogram: EGamma_SF2D
       file: data/sf/egamma/2017_egammaEffi_txt_EGM2D_runBCDEF_passingRECO.root
@@ -547,6 +551,9 @@ era2018:
         medium: 0.4184
         tight: 0.7527
   sf:
+    deepcsv:
+      file: data/sf/btag/DeepCSV_102XSF_WP_V1.csv
+
     ele_reco:
       histogram: EGamma_SF2D
       file: data/sf/egamma/2018_egammaEffi_txt_EGM2D_updatedAll.root

--- a/bucoffea/vbfhinv/definitions.py
+++ b/bucoffea/vbfhinv/definitions.py
@@ -92,6 +92,10 @@ def vbfhinv_accumulator(cfg):
     items["dphijj"] = Hist("Counts", dataset_ax, region_ax, dphi_ax)
     items["detajj"] = Hist("Counts", dataset_ax, region_ax, deta_ax)
 
+    if cfg.RUN.BTAG_STUDY:
+        items["mjj_bveto_up"] = Hist("Counts", dataset_ax, region_ax, mjj_ax)
+        items["mjj_bveto_down"] = Hist("Counts", dataset_ax, region_ax, mjj_ax)
+
     items["ak4_pt0"] = Hist("Counts", dataset_ax, region_ax, jet_pt_ax)
     items["ak4_ptraw0"] = Hist("Counts", dataset_ax, region_ax, jet_pt_ax)
     items["ak4_eta0"] = Hist("Counts", dataset_ax, region_ax, jet_eta_ax)

--- a/bucoffea/vbfhinv/vbfhinvProcessor.py
+++ b/bucoffea/vbfhinv/vbfhinvProcessor.py
@@ -240,9 +240,15 @@ class vbfhinvProcessor(processor.ProcessorABC):
         selection.add('veto_photon', photons.counts==0)
         selection.add('veto_tau', taus.counts==0)
         selection.add('at_least_one_tau', taus.counts>0)
-        selection.add('veto_b', bjets.counts==0)
         selection.add('mindphijr',df['minDPhiJetRecoil'] > cfg.SELECTION.SIGNAL.MINDPHIJR)
         selection.add('mindphijm',df['minDPhiJetMet'] > cfg.SELECTION.SIGNAL.MINDPHIJR)
+
+        # B jets are treated using veto weights
+        # So accept them in MC, but reject in data
+        if df['is_data']:
+            selection.add('veto_b', bjets.counts==0)
+        else:
+            selection.add('veto_b', pass_all)
 
         selection.add('dpfcalo_sr',np.abs(df['dPFCaloSR']) < cfg.SELECTION.SIGNAL.DPFCALO)
         selection.add('dpfcalo_cr',np.abs(df['dPFCaloCR']) < cfg.SELECTION.SIGNAL.DPFCALO)

--- a/bucoffea/vbfhinv/vbfhinvProcessor.py
+++ b/bucoffea/vbfhinv/vbfhinvProcessor.py
@@ -636,6 +636,12 @@ class vbfhinvProcessor(processor.ProcessorABC):
             ezfill('detajj',             deta=df["detajj"][mask],   weight=rweight[mask] )
             ezfill('mjj',                mjj=df["mjj"][mask],      weight=rweight[mask] )
 
+            # b-tag weight up and down variations
+            if cfg.RUN.BTAG_STUDY:
+                if not df['is_data']:
+                    rw = region_weights.partial_weight(exclude=exclude+['bveto'])
+                    ezfill('mjj_bveto_up',    mjj=df['mjj'][mask],  weight=(rw*(1-bsf_variations['up']).prod())[mask])
+                    ezfill('mjj_bveto_down',  mjj=df['mjj'][mask],  weight=(rw*(1-bsf_variations['down']).prod())[mask])
 
             if gen_v_pt is not None:
                 ezfill('gen_vpt', vpt=gen_v_pt[mask], weight=df['Generator_weight'][mask])

--- a/bucoffea/vbfhinv/vbfhinvProcessor.py
+++ b/bucoffea/vbfhinv/vbfhinvProcessor.py
@@ -49,6 +49,9 @@ from bucoffea.monojet.definitions import (
                                           photon_impurity_weights,
                                           data_driven_qcd_dataset
                                           )
+
+from bucoffea.monojet.monojetProcessor import btag_weights
+
 from bucoffea.vbfhinv.definitions import (
                                            vbfhinv_accumulator,
                                            vbfhinv_regions,
@@ -102,11 +105,6 @@ def trigger_selection(selection, df, cfg):
     selection.add('trig_mu', mask_or(df, cfg.TRIGGERS.MUON.SINGLE))
 
     return selection
-
-
-
-
-
 
 class vbfhinvProcessor(processor.ProcessorABC):
     def __init__(self, blind=False):
@@ -402,6 +400,11 @@ class vbfhinvProcessor(processor.ProcessorABC):
                 weights.add('prefire', np.ones(df.size))
 
             weights = candidate_weights(weights, df, evaluator, muons, electrons, photons, cfg)
+
+            # B jet veto weights
+            bsf_variations = btag_weights(bjets,cfg)
+            weights.add("bveto", (1-bsf_variations["central"]).prod())
+
             weights = pileup_weights(weights, df, evaluator, cfg)
             weights = ak4_em_frac_weights(weights, diak4, evaluator)
             if not (gen_v_pt is None):

--- a/bucoffea/vbfhinv/vbfhinvProcessor.py
+++ b/bucoffea/vbfhinv/vbfhinvProcessor.py
@@ -38,7 +38,8 @@ from bucoffea.helpers.gen import (
                                   fill_gen_v_info
                                  )
 from bucoffea.helpers.weights import (
-                                  get_veto_weights
+                                  get_veto_weights,
+                                  btag_weights
                                  )
 from bucoffea.monojet.definitions import (
                                           candidate_weights,
@@ -49,8 +50,6 @@ from bucoffea.monojet.definitions import (
                                           photon_impurity_weights,
                                           data_driven_qcd_dataset
                                           )
-
-from bucoffea.monojet.monojetProcessor import btag_weights
 
 from bucoffea.vbfhinv.definitions import (
                                            vbfhinv_accumulator,

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ tabulate
 klepto
 pycairo==1.19.1
 numba==0.50.1
+uproot-methods<0.9.0
+awkward<1.0.0
+uproot<4.0.0


### PR DESCRIPTION
Hey @AndreasAlbert , I included the b-tag weights in VBF processor. It essentially carries everything over from monojet: Same deepCSV source files and imports the same weight calculation function. Additionally, I added a configurable option to fill mjj spectra with b-tag up and down variations. Let me know what you think, or if you want any changes, thank you! 