### PR TITLE
buexec: Update filenames to look up for dataset lists (for DAS)

### DIFF
--- a/bucoffea/execute/dataset_definitions.py
+++ b/bucoffea/execute/dataset_definitions.py
@@ -47,9 +47,9 @@ def short_name(dataset):
 
 def load_lists():
     files = [
-        bucoffea_path(f"data/datasets/datasets_2016.txt"),
-        bucoffea_path(f"data/datasets/datasets_2017.txt"),
-        bucoffea_path(f"data/datasets/datasets_2018.txt")
+        bucoffea_path(f"data/datasets/datasets_nanoaod_v7_2016.txt"),
+        bucoffea_path(f"data/datasets/datasets_nanoaod_v7_2017.txt"),
+        bucoffea_path(f"data/datasets/datasets_nanoaod_v7_2018.txt")
     ]
     lines = []
     for fpath in files:


### PR DESCRIPTION
Hey @AndreasAlbert, while using buexec for submission from DAS, I realized there might be a small bug. I believe the files that contain the list of dataset names were renamed earlier, but the filenames in the script were the old ones, so this caused an error. In this commit, I updated the dataset names.