### PR TITLE
update lo_vs_nlo plotting script

### DIFF
--- a/bucoffea/plot/studies/lo_vs_nlo/lo_vs_nlo_monov.py
+++ b/bucoffea/plot/studies/lo_vs_nlo/lo_vs_nlo_monov.py
@@ -16,9 +16,11 @@ acc = None
 def commandline():
     parser = argparse.ArgumentParser(prog='Plotter.')
     parser.add_argument('inpath', type=str, help='Input folder to use.')
-    parser.add_argument('--region', type=str, default='.*', help='Region to plot.')
-    parser.add_argument('--distribution', type=str, default='.*', help='Distribution to plot.')
+    parser.add_argument('--region', type=str, default='(sr|cr_(1e|2e|1m|2m|g))_(loose|tight)_v', help='Region to plot.')
+    parser.add_argument('--nlo', action='store_true', help='Use NLO MC sample')
+    parser.add_argument('--distribution', type=str, default='(recoil$|met$|ak8_(pt|eta|mass)|electron_(pt|eta)|muon_(pt|eta|mt)|photon_(pt|eta)|di(electron|muon)_mass)', help='Distribution to plot.')
     parser.add_argument('--njobs','-j', type=int, default=6, help='number of jobs running plotter in parallell')
+    parser.add_argument('--mcscale', type=float, default=None, help='scale SR MC by factor')
     args = parser.parse_args()
     return args
 
@@ -29,37 +31,32 @@ def _load_and_plot(args):
     returns nothing
     '''
     global acc
-    # make_plot(acc, region=region,distribution=distribution, year=year, data=data, mc=mc, signal=signal, outdir="./output/LO", output_format="png")
     try:
-        inpath = args['inpath']
-        region = args['region']
-        distribution = args['distribution']
-        year = args['year']
-        data = args['data']
-        mc = args['mc']
-        signal = args['signal']
-        outdir = args['outdir']
-        output_format = args['output_format']
-    except KeyError:
-        print("invalid input: "+str(args))
-        return -1
-    try:
-        make_plot(acc, region=region,distribution=distribution, year=year, data=data, mc=mc, signal=signal, outdir=outdir, output_format=output_format)
-        make_plot(acc, region=region,distribution=distribution, year=year, data=data, mc=mc, signal=signal, outdir=outdir+'/'+region, output_format="pdf")
+        make_plot(acc, **args)
+        if not args["output_format"] == "pdf":
+            args["output_format"] = "pdf"
+        make_plot(acc, **args)
     except AssertionError:
         print("invalid input: "+str(args))
-        raise AssertionError
-    except ValueError:
-        print("invalid input: "+str(args))
-        raise ValueError
     return 0
 
     
 
 def main(sysargs):
+    if not sysargs.nlo:
+        print("Warning: You are plotting with LO VJets MC samples, which is not the recommended version. Please use --nlo")
     global acc
     inpath = sysargs.inpath
-    ##### load the archive as global variable
+
+    # The processor output is stored in an
+    # 'accumulator', which in our case is
+    # just a dictionary holding all the histograms
+    # Put all your *coffea files into 'indir' and
+    # pass the directory as an argument here.
+    # All input files in the direcotry will
+    # automatically be found, merged and read.
+    # The merging only happens the first time
+    # you run over a specific set of inputs.
     acc = dir_archive(
         inpath,
         serialized=True,
@@ -88,27 +85,39 @@ def main(sysargs):
     
     args_list = []
     for year in [2017,2018]:
-        mc_map = {
-            'cr_1m_v'      : re.compile(f'(Top.*FXFX|Diboson|QCD_HT|DYJetsToLL_M-50_HT_MLM|WJetsToLNu.*HT).*{year}'),
-            'cr_1e_v'      : re.compile(f'(Top.*FXFX|Diboson|QCD_HT|DYJetsToLL_M-50_HT_MLM|WJetsToLNu.*HT|GJets_1j).*{year}'),
-            'cr_2m_v'      : re.compile(f'(Top.*FXFX|Diboson|DYJetsToLL_M-50_HT_MLM).*{year}'),
-            'cr_2e_v'      : re.compile(f'(Top.*FXFX|Diboson|DYJetsToLL_M-50_HT_MLM).*{year}'),
-            'cr_g_v'       : re.compile(f'(Diboson|QCD_HT|GJets_1j|VQQGamma_FXFX|WJetsToLNu.*HT).*{year}'),
-            'cr_nobveto_v' : re.compile(f'(Top.*FXFX|Diboson|QCD_HT|DYJetsToLL_M-50_HT_MLM|WJetsToLNu.*HT|GJets_1j|ZJetsToNuNu).*{year}'),
-            'sr_v'         : re.compile(f'(Top.*FXFX|Diboson|QCD_HT|DYJetsToLL_M-50_HT_MLM|WJetsToLNu.*HT|GJets_1j|ZJetsToNuNu).*{year}'),
-        }
-        #for raw_region in ['cr_1m_v','cr_2m_v','cr_1e_v','cr_2e_v','cr_g_v']:
-        for raw_region in ['cr_1m_v','cr_2m_v','cr_1e_v','cr_2e_v','cr_g_v','sr_v','cr_nobveto_v']:
-        #for raw_region in ['sr_v']:
+        if sysargs.nlo:
+            tag = "nlo"
+            if year==2017:
+                wjets_nlo_regex = ".*WNJetsToLNu.*"
+            elif year==2018:
+                wjets_nlo_regex = "WJetsToLNu.*FXFX.*"
+            mc_map = {
+                    'cr_1m_v' : re.compile(f'(Top_FXFX|Diboson|QCD_HT|DYNJetsToLL|{wjets_nlo_regex}).*{year}'),
+                    'cr_1e_v' : re.compile(f'(Top_FXFX|Diboson|QCD_HT|DYNJetsToLL|{wjets_nlo_regex}|GJets_1j_).*{year}'),
+                    'cr_2m_v' : re.compile(f'(Top_FXFX|Diboson|DYNJetsToLL).*{year}'),
+                    'cr_2e_v' : re.compile(f'(Top_FXFX|Diboson|DYNJetsToLL).*{year}'),
+                    'cr_g_v' : re.compile(f'(GJets_1j_|VQQGamma_FXFX|QCD_data|Diboson|{wjets_nlo_regex}).*{year}'),
+                    'sr_v' : re.compile(f'(Top_FXFX|Diboson|QCD_HT|DYNJetsToLL|{wjets_nlo_regex}|GJets_1j_|ZNJetsToNuNu.*FXFX).*{year}'),
+                    }
+        else:
+            tag = "losf"
+            mc_map = {
+                'cr_1m_v'      : re.compile(f'(Top_FXFX|Diboson|QCD_HT|DYJetsToLL_M-50_HT_MLM|WJetsToLNu.*HT).*{year}'),
+                'cr_1e_v'      : re.compile(f'(Top_FXFX|Diboson|QCD_HT|DYJetsToLL_M-50_HT_MLM|WJetsToLNu.*HT|GJets_DR).*{year}'),
+                'cr_2m_v'      : re.compile(f'(Top_FXFX|Diboson|DYJetsToLL_M-50_HT_MLM).*{year}'),
+                'cr_2e_v'      : re.compile(f'(Top_FXFX|Diboson|DYJetsToLL_M-50_HT_MLM).*{year}'),
+                'cr_g_v'       : re.compile(f'(Diboson|QCD_data|GJets_DR|VQQGamma_FXFX|WJetsToLNu.*HT).*{year}'),
+                'sr_v'         : re.compile(f'(Top_FXFX|Diboson|QCD_HT|DYJetsToLL_M-50_HT_MLM|WJetsToLNu.*HT|GJets_DR|ZJetsToNuNu).*{year}'),
+            }
+        for raw_region in mc_map.keys():
             for wp in ['','_inclusive','_loose','_tight','_loosemd','_tightmd']:
-            #for wp in ['']:
                 region = raw_region.replace('_v',wp+'_v')
                 if not re.match(sysargs.region, region):
                     continue
                 signal=None
 
                 if ("_1e_" in region) or ("_2e_" in region) or ("_g_" in region): data = re.compile(f'EGamma_{year}')
-                elif 'sr_' in region: data=None; signal=re.compile(f'WH.*{year}')
+                #elif 'sr_' in region: data=None; signal=re.compile(f'WH.*{year}')
                 else: data = re.compile(f'MET_{year}')
 
                 mc = mc_map[raw_region]
@@ -121,7 +130,6 @@ def main(sysargs):
                     if not re.match(sysargs.distribution, distribution):
                         continue
                     args={}
-                    args["inpath"]=inpath
                     args["region"]=region
                     args["distribution"]=distribution
                     args["year"]=year
@@ -131,7 +139,9 @@ def main(sysargs):
                         pattern = mc.pattern.replace("QCD_HT","QCD_data")
                         args["mc"] = re.compile(pattern)
                     args["signal"]=signal
-                    #args["outdir"]="./output/" + inpath.split
+                    args["tag"]=tag
+                    if sysargs.mcscale:
+                        args["mcscale"] = sysargs.mcscale
                     args["outdir"] = pjoin('./output/',list(filter(lambda x:x,inpath.split('/')))[-1])
                     args["output_format"]="png"
                     args_list.append(args)


### PR DESCRIPTION
Update the lo_vs_nlo.py and lo_vs_nlo_monov.py:

- Add option to use nlo and reflect it in output file name, tag="nlo"/"losf"
- Add option to scale signal region MC
- Default value of --region and --distribution now produces files currently used in AN rather than ".*"