### PR TITLE
Limit input: Use VBF samples with dipole recoil

### DIFF
--- a/bucoffea/data/datasets/xs/xs.yml
+++ b/bucoffea/data/datasets/xs/xs.yml
@@ -3647,6 +3647,8 @@ VBF_HToInvisible_M110_pow_pythia8_2016:
 VBF_HToInvisible_M125_PSweights_pow_pythia8_2018:
   gen: 3.861
   nnlo: 3.782
+VBF_HToInvisible_M125_withDipoleRecoil_pow_pythia8_2018:
+  nnlo: 3.782
 VBF_HToInvisible_M125_pow_pythia8_2016:
   gen: 0.0
   nnlo: 3.782

--- a/bucoffea/limit/legacy_vbf.py
+++ b/bucoffea/limit/legacy_vbf.py
@@ -45,7 +45,7 @@ def datasets(year, unblind=False):
 
 def legacy_dataset_name_vbf(dataset):
 
-    m = re.match("VBF_HToInvisible_M(\d+)(_PSweights)?_pow_pythia8_201[0-9]", dataset)
+    m = re.match("VBF_HToInvisible_M(\d+)(_withDipoleRecoil)?(_PSweights)?_pow_pythia8_201[0-9]", dataset)
     if m:
         mh = m.groups()[0]
         if mh=="125":

--- a/bucoffea/limit/legacy_vbf.py
+++ b/bucoffea/limit/legacy_vbf.py
@@ -216,7 +216,10 @@ def legacy_limit_input_vbf(acc, outdir='./output', unblind=False):
 
                 th1 = export1d(ih.integrate('dataset', dataset))
                 try:
-                    histo_name = f'{legacy_region_name(region)}_{legacy_dataset_name_vbf(dataset)}'
+                    # Patch for now: We only have the DR sample for 2018
+                    # So we modify the function "DR" argument based on which year we're looking at
+                    use_dr = year == 2018
+                    histo_name = f'{legacy_region_name(region)}_{legacy_dataset_name_vbf(dataset, vbf_with_dipole_recoil=use_dr )}'
                     print(f'Saved under histogram: {histo_name}')
                 except:
                     print(f"Skipping {dataset}")

--- a/bucoffea/limit/legacy_vbf.py
+++ b/bucoffea/limit/legacy_vbf.py
@@ -43,15 +43,36 @@ def datasets(year, unblind=False):
 
     return data, mc
 
-def legacy_dataset_name_vbf(dataset):
-
-    m = re.match("VBF_HToInvisible_M(\d+)(_withDipoleRecoil)?(_PSweights)?_pow_pythia8_201[0-9]", dataset)
+def legacy_dataset_name_vbf(dataset, vbf_with_dipole_recoil=True):
+    # For the VBF samples, we have two processes:
+    # VBF with dipole recoil ON / OFF
+    # The default one (as provided in the function argument) will be mapped to "vbf"
+    m = re.match("VBF_HToInvisible_M(\d+)(_PSweights)?_pow_pythia8_201[0-9]", dataset)
     if m:
         mh = m.groups()[0]
-        if mh=="125":
-            return "vbf"
+        if vbf_with_dipole_recoil:
+            dr_suffix = '_noDR'
         else:
-            return f"vbf{mh}"
+            dr_suffix = ''
+        
+        if mh=="125":
+            return f"vbf{dr_suffix}"
+        else:
+            return f"vbf{mh}{dr_suffix}"
+
+    m = re.match("VBF_HToInvisible_M(\d+)_withDipoleRecoil(_PSweights)?_pow_pythia8_201[0-9]", dataset)
+    if m:
+        mh = m.groups()[0]
+        if vbf_with_dipole_recoil:
+            dr_suffix = ''
+        else:
+            dr_suffix = '_withDR'
+
+        if mh=="125":
+            return f"vbf{dr_suffix}"
+        else:
+            return f"vbf{mh}{dr_suffix}"
+
     m = re.match("ZH_ZToQQ_HToInvisible_M(\d+)(_PSweights)?_pow_pythia8_201[0-9]", dataset)
     if m:
         mh = m.groups()[0]


### PR DESCRIPTION
Hey @AndreasAlbert, I think this was somehow stuck in another branch and not merged into master. I just changed the regular expression for VBF signal so that we match the one with dipole recoil as well. With the current version, it matches both the non-DR and DR sample, is it possible to maybe move the non-DR 2018 sample to a temp/ directory on 03Sep20v7 so that we don't process that at all? What do you think? Thanks! 